### PR TITLE
feat(plex): optimize volsync backup with .kopiaignore

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -14,6 +14,20 @@ spec:
       plex:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          # Copy .kopiaignore to config volume root for Volsync backup optimization
+          # Excludes regenerable metadata (~7GB) to speed up backups
+          kopiaignore:
+            image:
+              repository: ghcr.io/home-operations/alpine
+              tag: 3.21.3@sha256:bf9f7e405036f7d9c42a26da7bd0c2bd535faec8cbc1bfba6b0db33590e4ff28
+            command: ["/bin/sh", "-c"]
+            args:
+              - cp /kopiaignore/.kopiaignore /config/.kopiaignore
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
         containers:
           app:
             image:
@@ -113,6 +127,11 @@ spec:
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"
+      kopiaignore:
+        type: configMap
+        name: plex-kopiaignore
+        globalMounts:
+          - path: /kopiaignore
       tmp:
         type: emptyDir
       media:

--- a/kubernetes/apps/media/plex/app/kopiaignore.yaml
+++ b/kubernetes/apps/media/plex/app/kopiaignore.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plex-kopiaignore
+data:
+  .kopiaignore: |
+    # Regenerable from web (TMDB/TVDB) - saves ~7GB
+    Cache/
+    Metadata/
+    
+    # Logs and diagnostics - not needed for restore
+    Logs/
+    Crash Reports/
+    Diagnostics/
+    
+    # Auto-downloaded on startup
+    Codecs/
+    Updates/
+    
+    # Misc
+    *.log
+    *.log.*

--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./kopiaignore.yaml


### PR DESCRIPTION
## Summary
Adds a `.kopiaignore` file to exclude regenerable data from Plex backups.

## Changes
- New ConfigMap with `.kopiaignore` exclusion rules
- Init container to copy the file to the config volume root
- Excludes ~7GB of data that can be re-fetched from TMDB/TVDB

## Excluded paths
| Path | Reason |
|------|--------|
| `Metadata/` | ~7GB of images, re-downloaded from TMDB/TVDB |
| `Cache/` | Temporary cache, regenerated |
| `Logs/` | Not needed for restore |
| `Crash Reports/` | Not needed for restore |
| `Diagnostics/` | Not needed for restore |
| `Codecs/` | Auto-downloaded on startup |
| `Updates/` | Auto-downloaded on startup |

## What's still backed up
- `Plug-in Support/Databases/` - watch history, playlists, users
- `Preferences.xml` - server configuration
- `Media/` - preview thumbnails

## Expected improvement
- Backup time: ~7min → <2min
- Backup size: ~14GB → ~7GB