### PR TITLE
feat(self-hosted/plane): add Plane CE via HelmRepository

### DIFF
--- a/kubernetes/apps/self-hosted/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/plane/app/helmrelease.yaml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/makeplane/helm-charts/main/charts/plane-ce/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plane
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: plane-ce
+      version: "1.5.0"
+      sourceRef:
+        kind: HelmRepository
+        name: plane
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    planeVersion: v1.2.3
+    # Image pull for ghcr.io
+    dockerRegistry:
+      enabled: true
+      host: ghcr.io
+      loginid: puchu-ai
+      password: CHANGEME_GHCR_TOKEN
+    # Ingress
+    ingress:
+      enabled: true
+      appHost: plane.oxygn.dev
+      ingressClass: cilium
+      ingress_annotations:
+        cilium.io/ingress-secure-port: "443"
+    # Storage
+    postgres:
+      local_setup: true
+      storageClass: ceph-block
+      volumeSize: 5Gi
+    redis:
+      local_setup: true
+      storageClass: ceph-block
+      volumeSize: 1Gi
+    rabbitmq:
+      local_setup: true
+      storageClass: ceph-block
+      volumeSize: 1Gi
+    minio:
+      local_setup: true
+      storageClass: ceph-block
+      volumeSize: 5Gi
+    # Admin settings
+    admin:
+      enabled: true
+      email: admin@oxygn.dev
+    # Secrets
+    env:
+      secret_key: ZWX26VJdlcVHqgmdsCwA7wM+9/lQI4m6iyL139tHJ8A=
+      live_server_secret_key: htbqvBJAgpm9bzvf3r4urJer0ENReatceh
+      pgdb_username: plane
+      pgdb_password: plane_pg_password
+      pgdb_name: plane
+    # Scale
+    api:
+      replicas: 1
+      memoryLimit: 1000Mi
+    web:
+      replicas: 1
+      memoryLimit: 1000Mi
+    worker:
+      replicas: 1
+    space:
+      replicas: 1
+    live:
+      replicas: 1
+    admin:
+      replicas: 1
+    beatworker:
+      replicas: 1

--- a/kubernetes/apps/self-hosted/plane/app/helmrepository.yaml
+++ b/kubernetes/apps/self-hosted/plane/app/helmrepository.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: plane
+spec:
+  interval: 15m
+  url: https://helm.plane.so/

--- a/kubernetes/apps/self-hosted/plane/app/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/plane/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/self-hosted/plane/ks.yaml
+++ b/kubernetes/apps/self-hosted/plane/ks.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plane
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: plane
+  interval: 1h
+  path: ./kubernetes/apps/self-hosted/plane/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: self-hosted
+  wait: true


### PR DESCRIPTION
## Summary

Deploy Plane Community Edition using the public Helm repository (helm.plane.so).

## Changes

- Add HelmRepository (https://helm.plane.so/) - no auth needed
- Add HelmRelease: plane-ce chart v1.5.0
- Ingress: plane.oxygn.dev (Cilium)
- Storage: postgres/redis/rabbitmq/minio on ceph-block
- Admin email: admin@oxygn.dev

## Post-merge actions

1. Update `dockerRegistry.password` in helmrelease.yaml with real ghcr.io token via ExternalSecret
2. Flux will reconcile and deploy Plane