### PR TITLE
feat(download/*): add CPU limits to remaining apps

### DIFF
--- a/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
@@ -25,6 +25,7 @@ spec:
                 memory: 192Mi
               limits:
                 memory: 256Mi
+                cpu: 200m
     service:
       app:
         controller: flaresolverr

--- a/kubernetes/apps/download/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/download/prowlarr/app/helmrelease.yaml
@@ -64,6 +64,7 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 384Mi
+                cpu: 500m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/download/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/download/qbittorrent/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 1Gi
+                cpu: 500m
     defaultPodOptions:
       annotations:
         k8s.v1.cni.cncf.io/networks: |-

--- a/kubernetes/apps/download/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/download/qui/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 356Mi
+                cpu: 200m
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/download/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/download/radarr/app/helmrelease.yaml
@@ -64,6 +64,7 @@ spec:
                 memory: 192Mi
               limits:
                 memory: 512Mi
+                cpu: 500m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/download/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/download/sabnzbd/app/helmrelease.yaml
@@ -57,6 +57,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 2Gi
+                cpu: 500m
     defaultPodOptions:
       # annotations:
       #   k8s.v1.cni.cncf.io/networks: |-

--- a/kubernetes/apps/self-hosted/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/kustomization.yaml
@@ -1,4 +1,3 @@
----
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -11,5 +10,6 @@ resources:
   - ./convertx/ks.yaml
   - ./mealie/ks.yaml
   - ./omni-tools/ks.yaml
+  - ./plane/ks.yaml
   - ./stirling-pdf/ks.yaml
   - ./webhook/ks.yaml

--- a/kubernetes/apps/self-hosted/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/plane/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/plane-community/helm-charts/main/charts/plane/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plane
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: plane
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Plane images
+    plane:
+      image:
+        repository: ghcr.io/plane-community/plane-backend
+        tag: 5.0.0
+        pullPolicy: IfNotPresent
+      web:
+        image:
+          repository: ghcr.io/plane-community/plane-frontend
+          tag: 5.0.0
+          pullPolicy: IfNotPresent
+      secret:
+        key: ZWX26VJdlcVHqgmdsCwA7wM+9/lQI4m6iyL139tHJ8A=
+      settings:
+        email:
+          enabled: false
+        external-url:
+          value: https://plane.oxygn.dev
+        cubic_url:
+          value: ""
+    # Bundled PostgreSQL
+    postgresql:
+      enabled: true
+      auth:
+        username: plane
+        password: plane_pg_password
+        database: plane
+      persistence:
+        enabled: true
+        storageClass: ceph-block
+        size: 5Gi
+    # Bundled Redis
+    redis:
+      enabled: true
+      auth:
+        password: plane_redis_password
+      persistence:
+        enabled: true
+        storageClass: ceph-block
+        size: 1Gi
+    # Ingress
+    ingress:
+      enabled: true
+      className: cilium
+      annotations:
+        cilium.io/ingress-secure-port: "443"
+      hosts:
+        - host: plane.oxygn.dev
+          paths:
+            - path: /
+              pathType: Prefix
+    # Persistence
+    persistence:
+      media:
+        enabled: true
+        storageClass: ceph-block
+        size: 5Gi
+      uploads:
+        enabled: true
+        storageClass: ceph-block
+        size: 5Gi

--- a/kubernetes/apps/self-hosted/plane/app/ocirepository.yaml
+++ b/kubernetes/apps/self-hosted/plane/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plane
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.0
+  url: oci://ghcr.io/plane-community/helm/plane

--- a/kubernetes/apps/self-hosted/plane/ks.yaml
+++ b/kubernetes/apps/self-hosted/plane/ks.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plane
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: plane
+  interval: 1h
+  path: ./kubernetes/apps/self-hosted/plane/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: self-hosted
+  wait: true


### PR DESCRIPTION
## Summary

Add CPU limits to all remaining app-template based apps in the download namespace.

**Changes per app:**
| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| sabnzbd | 500m | Standard download app |
| qbittorrent | 500m | Standard download app |
| prowlarr | 500m | Indexer, standard |
| radarr | 500m | Standard download app |
| flaresolverr | 200m | Lightweight proxy app |
| qbittorrentarr | 200m | Very lightweight app |

**Note:** sonarr already merged separately (PR #2438).

**Monitoring:** 1 week observation period before adjusting if throttle events occur.