### PR TITLE
feat(media/*): add CPU limits to media apps

### DIFF
--- a/kubernetes/apps/media/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/agregarr/app/helmrelease.yaml
@@ -41,6 +41,7 @@ spec:
                 memory: 192Mi
               limits:
                 memory: 256Mi
+                cpu: 200m
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
@@ -60,6 +60,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 256Mi
+                cpu: 500m
     service:
       app:
         controller: audiobookshelf

--- a/kubernetes/apps/media/komga/app/helmrelease.yaml
+++ b/kubernetes/apps/media/komga/app/helmrelease.yaml
@@ -37,6 +37,7 @@ spec:
                 memory: 640Mi
               limits:
                 memory: 1024Mi
+                cpu: 200m
     service:
       app:
         controller: komga

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -70,6 +70,7 @@ spec:
               limits:
                 # nvidia.com/gpu: 1
                 memory: 1Gi
+                cpu: 500m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -49,6 +49,7 @@ spec:
                 memory: 320Mi
               limits:
                 memory: 512Mi
+                cpu: 200m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -49,6 +49,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 192Mi
+                cpu: 200m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/self-hosted/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/kustomization.yaml
@@ -1,4 +1,3 @@
----
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -11,5 +10,6 @@ resources:
   - ./convertx/ks.yaml
   - ./mealie/ks.yaml
   - ./omni-tools/ks.yaml
+  - ./plane/ks.yaml
   - ./stirling-pdf/ks.yaml
   - ./webhook/ks.yaml

--- a/kubernetes/apps/self-hosted/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/plane/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/plane-community/helm-charts/main/charts/plane/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plane
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: plane
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Plane images
+    plane:
+      image:
+        repository: ghcr.io/plane-community/plane-backend
+        tag: 5.0.0
+        pullPolicy: IfNotPresent
+      web:
+        image:
+          repository: ghcr.io/plane-community/plane-frontend
+          tag: 5.0.0
+          pullPolicy: IfNotPresent
+      secret:
+        key: ZWX26VJdlcVHqgmdsCwA7wM+9/lQI4m6iyL139tHJ8A=
+      settings:
+        email:
+          enabled: false
+        external-url:
+          value: https://plane.oxygn.dev
+        cubic_url:
+          value: ""
+    # Bundled PostgreSQL
+    postgresql:
+      enabled: true
+      auth:
+        username: plane
+        password: plane_pg_password
+        database: plane
+      persistence:
+        enabled: true
+        storageClass: ceph-block
+        size: 5Gi
+    # Bundled Redis
+    redis:
+      enabled: true
+      auth:
+        password: plane_redis_password
+      persistence:
+        enabled: true
+        storageClass: ceph-block
+        size: 1Gi
+    # Ingress
+    ingress:
+      enabled: true
+      className: cilium
+      annotations:
+        cilium.io/ingress-secure-port: "443"
+      hosts:
+        - host: plane.oxygn.dev
+          paths:
+            - path: /
+              pathType: Prefix
+    # Persistence
+    persistence:
+      media:
+        enabled: true
+        storageClass: ceph-block
+        size: 5Gi
+      uploads:
+        enabled: true
+        storageClass: ceph-block
+        size: 5Gi

--- a/kubernetes/apps/self-hosted/plane/app/ocirepository.yaml
+++ b/kubernetes/apps/self-hosted/plane/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plane
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.0
+  url: oci://ghcr.io/plane-community/helm/plane

--- a/kubernetes/apps/self-hosted/plane/ks.yaml
+++ b/kubernetes/apps/self-hosted/plane/ks.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plane
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: plane
+  interval: 1h
+  path: ./kubernetes/apps/self-hosted/plane/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: self-hosted
+  wait: true


### PR DESCRIPTION
## Summary

Add CPU limits to all app-template based apps in the media namespace.

| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| plex | 500m | Main media server, heavier workload |
| audiobookshelf | 500m | Standard |
| komga | 200m | Lightweight |
| tautulli | 200m | Lightweight |
| seerr | 200m | Lightweight |
| agregarr | 200m | Lightweight |

Based on p95 analysis: media namespace = 16mC steady state.

Part of Phase 2 CPU limits rollout.