### PR TITLE
feat(self-hosted,automation,ai): add CPU limits to remaining apps

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -47,6 +47,7 @@ spec:
               limits:
                 nvidia.com/gpu: 1
                 memory: 6Gi
+                cpu: 2000m
 
         pod:
           affinity:

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -36,6 +36,7 @@ spec:
                 cpu: 200m
               limits:
                 memory: 2Gi
+                cpu: 2000m
 
     service:
       app:

--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -171,6 +171,7 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 4Gi
+                cpu: 1000m
 
           # -- Chromium sidecar for browser automation (CDP on port 9222)
           chrome:

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -36,6 +36,7 @@ spec:
                 memory: 832Mi
               limits:
                 memory: 1Gi
+                cpu: 200m
           codeserver:
             image:
               repository: ghcr.io/coder/code-server

--- a/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
@@ -29,6 +29,7 @@ spec:
                 cpu: 10m
               limits:
                 memory: 100Mi
+                cpu: 100m
         statefulset:
           volumeClaimTemplates:
             - name: config

--- a/kubernetes/apps/automation/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/teslamate/app/helmrelease.yaml
@@ -66,3 +66,4 @@ spec:
         memory: 256Mi
       limits:
         memory: 384Mi
+                cpu: 200m

--- a/kubernetes/apps/renovate/renovate-operator/jobs/github.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/github.yaml
@@ -32,7 +32,7 @@ spec:
       value: '["pnpm run bundle"]'
     - name: RENOVATE_PLATFORM_COMMIT
       value: "true"
-  image: ghcr.io/renovatebot/renovate:43.122.0
+  image: ghcr.io/renovatebot/renovate:43.123.2
   parallelism: 5
   resources:
     requests:

--- a/kubernetes/apps/self-hosted/actual/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/actual/app/helmrelease.yaml
@@ -57,6 +57,7 @@ spec:
                 memory: 128M
               limits:
                 memory: 512M
+                cpu: 200m
     service:
       app:
         controller: actual

--- a/kubernetes/apps/self-hosted/convertx/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/convertx/app/helmrelease.yaml
@@ -40,6 +40,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 512Mi
+                cpu: 200m
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/self-hosted/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/mealie/app/helmrelease.yaml
@@ -46,6 +46,7 @@ spec:
                 memory: 256M
               limits:
                 memory: 512M
+                cpu: 200m
     service:
       app:
         controller: mealie

--- a/kubernetes/apps/self-hosted/omni-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/omni-tools/app/helmrelease.yaml
@@ -29,6 +29,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 512Mi
+                cpu: 200m
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/kubernetes/apps/self-hosted/stirling-pdf/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/stirling-pdf/app/helmrelease.yaml
@@ -48,6 +48,7 @@ spec:
                 memory: 256M
               limits:
                 memory: 2Gi
+                cpu: 500m
             # securityContext:
             #   readOnlyRootFilesystem: true
         # pod:

--- a/kubernetes/apps/self-hosted/webhook/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/webhook/app/helmrelease.yaml
@@ -40,6 +40,7 @@ spec:
                 cpu: 10m
               limits:
                 memory: 512Mi
+                cpu: 200m
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

Add CPU limits to app-template based apps in self-hosted, automation, and ai namespaces.

### self-hosted
| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| actual | 200m | Lightweight |
| convertx | 200m | Lightweight |
| mealie | 200m | Lightweight |
| omni-tools | 200m | Lightweight |
| stirling-pdf | 500m | PDF processing |
| webhook | 200m | Lightweight |

### automation
| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| home-assistant | 200m | Standard |
| mosquitto | 100m | Very lightweight MQTT broker |
| teslamate | 200m | Standard |

### ai
| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| ollama | 2000m | GPU workload, needs CPU for orchestration |
| openclaw | 1000m | Chromium browser automation |
| open-webui | 2000m | AI UI, heavier workload |

**Note:** plane (self-hosted) skipped - uses different Helm chart structure.

Part of Phase 2 CPU limits rollout.