### PR TITLE
feat(media/*): add CPU limits to media apps

### DIFF
--- a/kubernetes/apps/media/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/agregarr/app/helmrelease.yaml
@@ -41,6 +41,7 @@ spec:
                 memory: 192Mi
               limits:
                 memory: 256Mi
+                cpu: 200m
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
@@ -60,6 +60,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 256Mi
+                cpu: 500m
     service:
       app:
         controller: audiobookshelf

--- a/kubernetes/apps/media/komga/app/helmrelease.yaml
+++ b/kubernetes/apps/media/komga/app/helmrelease.yaml
@@ -37,6 +37,7 @@ spec:
                 memory: 640Mi
               limits:
                 memory: 1024Mi
+                cpu: 200m
     service:
       app:
         controller: komga

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -70,6 +70,7 @@ spec:
               limits:
                 # nvidia.com/gpu: 1
                 memory: 1Gi
+                cpu: 2000m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -49,6 +49,7 @@ spec:
                 memory: 320Mi
               limits:
                 memory: 512Mi
+                cpu: 200m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -49,6 +49,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 192Mi
+                cpu: 200m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Summary

Add CPU limits to app-template based apps in the media namespace.

| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| plex | 2000m | Transcoding workload |
| audiobookshelf | 500m | Standard |
| komga | 200m | Lightweight |
| tautulli | 200m | Lightweight |
| seerr | 200m | Lightweight |
| agregarr | 200m | Lightweight |

Based on p95 analysis: media namespace = 16mC steady state.


Part of Phase 2 CPU limits rollout.