### PR TITLE
feat(automation): add CPU limits

### DIFF
--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -36,6 +36,7 @@ spec:
                 memory: 832Mi
               limits:
                 memory: 1Gi
+                cpu: 200m
           codeserver:
             image:
               repository: ghcr.io/coder/code-server

--- a/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
@@ -29,6 +29,7 @@ spec:
                 cpu: 10m
               limits:
                 memory: 100Mi
+                cpu: 100m
         statefulset:
           volumeClaimTemplates:
             - name: config

--- a/kubernetes/apps/automation/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/teslamate/app/helmrelease.yaml
@@ -66,3 +66,4 @@ spec:
         memory: 256Mi
       limits:
         memory: 384Mi
+        cpu: 200m


### PR DESCRIPTION
## Summary

Add CPU limits to automation namespace apps.

| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| home-assistant | 200m | Standard |
| mosquitto | 100m | Very lightweight MQTT broker |
| teslamate | 200m | Standard |

Part of Phase 2 CPU limits rollout.