### PR TITLE
feat(self-hosted): add CPU limits

### DIFF
--- a/kubernetes/apps/self-hosted/actual/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/actual/app/helmrelease.yaml
@@ -57,6 +57,7 @@ spec:
                 memory: 128M
               limits:
                 memory: 512M
+                cpu: 200m
     service:
       app:
         controller: actual

--- a/kubernetes/apps/self-hosted/convertx/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/convertx/app/helmrelease.yaml
@@ -40,6 +40,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 512Mi
+                cpu: 200m
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/self-hosted/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/mealie/app/helmrelease.yaml
@@ -46,6 +46,7 @@ spec:
                 memory: 256M
               limits:
                 memory: 512M
+                cpu: 200m
     service:
       app:
         controller: mealie

--- a/kubernetes/apps/self-hosted/omni-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/omni-tools/app/helmrelease.yaml
@@ -29,6 +29,7 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 512Mi
+                cpu: 200m
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/kubernetes/apps/self-hosted/stirling-pdf/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/stirling-pdf/app/helmrelease.yaml
@@ -48,6 +48,7 @@ spec:
                 memory: 256M
               limits:
                 memory: 2Gi
+                cpu: 500m
             # securityContext:
             #   readOnlyRootFilesystem: true
         # pod:

--- a/kubernetes/apps/self-hosted/webhook/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/webhook/app/helmrelease.yaml
@@ -40,6 +40,7 @@ spec:
                 cpu: 10m
               limits:
                 memory: 512Mi
+                cpu: 200m
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

Add CPU limits to self-hosted namespace apps.

| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| actual | 200m | Lightweight |
| convertx | 200m | Lightweight |
| mealie | 200m | Lightweight |
| omni-tools | 200m | Lightweight |
| stirling-pdf | 500m | PDF processing |
| webhook | 200m | Lightweight |

Part of Phase 2 CPU limits rollout.