### PR TITLE
feat(ai): add CPU limits

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -47,6 +47,7 @@ spec:
               limits:
                 nvidia.com/gpu: 1
                 memory: 6Gi
+                cpu: 2000m
 
         pod:
           affinity:

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -36,6 +36,7 @@ spec:
                 cpu: 200m
               limits:
                 memory: 2Gi
+                cpu: 2000m
 
     service:
       app:

--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -171,6 +171,7 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 4Gi
+                cpu: 2000m
 
           # -- Chromium sidecar for browser automation (CDP on port 9222)
           chrome:


### PR DESCRIPTION
## Summary

Add CPU limits to ai namespace apps.

| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| ollama | 2000m | GPU workload, CPU for orchestration |
| openclaw | 2000m | Browser automation |
| open-webui | 2000m | AI UI |

Part of Phase 2 CPU limits rollout.