### PR TITLE
feat(network): add CPU limits

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -46,5 +46,12 @@ spec:
       failureThreshold: 10
     serviceMonitor:
       enabled: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
     podAnnotations:
       secret.reloader.stakater.com/reload: *secret

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -17,5 +17,12 @@ spec:
         provider:
           type: Kubernetes
           kubernetes:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
             deploy:
               type: GatewayNamespace


### PR DESCRIPTION
## Summary

Add CPU limits to network namespace apps (non app-template charts).

| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| cloudflare-dns | 200m | Lightweight DNS sync |
| envoy-gateway | 500m | Infrastructure proxy/gateway |

Note: certificates skipped (not a running workload).

Part of Phase 2 CPU limits rollout.