### PR TITLE
feat(actions-runner-system): add CPU limits

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
@@ -12,3 +12,10 @@ spec:
   values:
     fullnameOverride: actions-runner-controller
     replicaCount: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi


### PR DESCRIPTION
## Summary

Add CPU limits to actions-runner-controller (GitHub Actions operator).

| App | CPU Limit | Rationale |
|-----|-----------|-----------|
| actions-runner-controller | 200m | Lightweight runner scale-set controller |

Part of Phase 2 CPU limits rollout.