### PR TITLE
feat(database): add CPU limits

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
@@ -27,3 +27,11 @@ spec:
       podMonitorEnabled: false
       grafanaDashboard:
         create: true
+
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 2Gi

--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -16,3 +16,11 @@ spec:
     grafanaDashboard:
       enabled: true
       folder: database
+
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 2Gi

--- a/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -17,3 +17,10 @@ spec:
       enabled: true
     webhook:
       replicaCount: 2
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi


### PR DESCRIPTION
## Summary

Adds CPU limits to database namespace applications.

### Changes

| App | CPU Limit |
|-----|-----------|
| cloudnative-pg | 1000m (PostgreSQL operator) |
| dragonfly | 1000m (in-memory database) |

Part of Phase 2 CPU limits rollout.