### PR TITLE
feat(rook-ceph): add CPU limits

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -17,3 +17,10 @@ spec:
       enabled: true
     webhook:
       replicaCount: 2
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -21,6 +21,8 @@ spec:
       enabled: true
     resources:
       requests:
-        memory: 128Mi # unchangable
-        cpu: 100m # unchangable
-      limits: {}
+        memory: 512Mi
+        cpu: 200m
+      limits:
+        cpu: 1000m
+        memory: 2Gi


### PR DESCRIPTION
feat(rook-ceph): add CPU limits

- rook-ceph operator: 1000m (storage orchestrator)

Note: rook-ceph-cluster worker daemons (OSD) may need separate configuration.

Part of Phase 2 CPU limits rollout.