### PR TITLE
feat(ai): add searxng search engine

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -9,3 +9,4 @@ components:
 resources:
   - ./namespace.yaml
   # - ./openclaw/ks.yaml
+  - ./searxng/ks.yaml

--- a/kubernetes/apps/ai/searxng/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/searxng/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: searxng
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: searxng
+    template:
+      data:
+        SEARXNG_SECRET: "{{ .SEARXNG_SECRET }}"
+  dataFrom:
+    - extract:
+        key: searxng

--- a/kubernetes/apps/ai/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/searxng/app/helmrelease.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: searxng
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: searxng
+  interval: 15m
+  values:
+    controllers:
+      searxng:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 2
+        strategy: RollingUpdate
+        containers:
+          main:
+            image:
+              repository: ghcr.io/searxng/searxng
+              tag: 2025.11.18-576c8ca99@sha256:91da34403fc1d2c7ac23d1459af87870d87810b7d50b0c6a4585ab78846cb534
+            env:
+              SEARXNG_BASE_URL: https://search.oxygn.dev
+              SEARXNG_PORT: &port 8080
+              SEARXNG_REDIS_URL: "redis://dragonfly.database:6379"
+            envFrom:
+              - secretRef:
+                  name: searxng
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /stats
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /stats
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 10m
+                memory: 215Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - CHOWN
+                  - SETGID
+                  - SETUID
+                  - DAC_OVERRIDE
+    persistence:
+      config:
+        type: configMap
+        name: searxng-configmap
+        globalMounts:
+          - path: /etc/searxng/settings.yml
+            subPath: settings.yml
+            readOnly: true
+          - path: /etc/searxng/limiter.toml
+            subPath: limiter.toml
+            readOnly: true
+      tmpfs:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    route:
+      app:
+        hostnames:
+          - search.oxygn.dev
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/ai/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/searxng/app/helmrelease.yaml
@@ -14,17 +14,17 @@ spec:
       searxng:
         annotations:
           reloader.stakater.com/auto: "true"
-        replicas: 2
         strategy: RollingUpdate
+
         containers:
           main:
             image:
-              repository: ghcr.io/searxng/searxng
-              tag: 2025.11.18-576c8ca99@sha256:91da34403fc1d2c7ac23d1459af87870d87810b7d50b0c6a4585ab78846cb534
+              repository: docker.io/searxng/searxng
+              tag: 2024.6.30-39aaac40d
             env:
               SEARXNG_BASE_URL: https://search.oxygn.dev
               SEARXNG_PORT: &port 8080
-              SEARXNG_REDIS_URL: "redis://dragonfly.database:6379"
+              SEARXNG_REDIS_URL: redis://localhost:6379
             envFrom:
               - secretRef:
                   name: searxng
@@ -54,7 +54,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 215Mi
+                memory: 256Mi
               limits:
                 memory: 1Gi
             securityContext:
@@ -68,6 +68,29 @@ spec:
                   - SETGID
                   - SETUID
                   - DAC_OVERRIDE
+
+          redis:
+            image:
+              repository: docker.io/valkey/valkey
+              tag: 8.0.1
+            args:
+              - --save
+              - ""
+              - --appendonly
+              - "no"
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+
     persistence:
       config:
         type: configMap
@@ -84,6 +107,8 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /tmp
+          - path: /etc/searxng
+
     route:
       app:
         hostnames:
@@ -91,8 +116,13 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+
     service:
       app:
         ports:
           http:
             port: *port
+      redis:
+        ports:
+          http:
+            port: 6379

--- a/kubernetes/apps/ai/searxng/app/kustomization.yaml
+++ b/kubernetes/apps/ai/searxng/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: searxng-configmap
+    files:
+      - ./resources/limiter.toml
+      - ./resources/settings.yml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/ai/searxng/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/searxng/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: searxng
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/searxng/app/resources/limiter.toml
+++ b/kubernetes/apps/ai/searxng/app/resources/limiter.toml
@@ -1,0 +1,38 @@
+[real_ip]
+
+# Number of values to trust for X-Forwarded-For.
+
+x_for = 1
+
+# The prefix defines the number of leading bits in an address that are compared
+# to determine whether or not an address is part of a (client) network.
+
+ipv4_prefix = 32
+ipv6_prefix = 48
+
+[botdetection.ip_limit]
+
+# To get unlimited access in a local network, by default link-lokal addresses
+# (networks) are not monitored by the ip_limit
+filter_link_local = true
+
+# activate link_token method in the ip_limit method
+link_token = false
+
+[botdetection.ip_lists]
+
+# In the limiter, the ip_lists method has priority over all other methods -> if
+# an IP is in the pass_ip list, it has unrestricted access and it is also not
+# checked if e.g. the "user agent" suggests a bot (e.g. curl).
+
+block_ip = [
+]
+
+pass_ip = [
+  '192.168.0.0/16',      # IPv4 private network
+  '10.0.0.0/8',          # IPv4 private network
+]
+
+# Activate passlist of (hardcoded) IPs from the SearXNG organization,
+# e.g. `check.searx.space`.
+pass_searxng_org = false

--- a/kubernetes/apps/ai/searxng/app/resources/settings.yml
+++ b/kubernetes/apps/ai/searxng/app/resources/settings.yml
@@ -1,0 +1,56 @@
+use_default_settings: true
+
+server:
+  limiter: true
+  image_proxy: true
+  method: GET
+  public_instance: false
+
+search:
+  autocomplete: duckduckgo
+  favicon_resolver: duckduckgo
+  languages:
+    - all
+    - en
+    - en-US
+  formats:
+    - html
+    - json
+
+general:
+  instance_name: Oxygn Search
+
+ui:
+  default_theme: simple
+  infinite_scroll: true
+  query_in_title: true
+  results_on_new_tab: true
+  static_use_hash: true
+  theme_args:
+    simple_style: auto
+
+categories_as_tabs:
+  general:
+  images:
+  videos:
+  map:
+
+enabled_plugins:
+  - Basic Calculator
+  - Hash plugin
+  - Open Access DOI rewrite
+  - Self Informations
+  - Tracker URL remover
+  - Unit converter plugin
+
+hostnames:
+  high_priority:
+    - (.*)\/blog\/(.*)
+    - (.*\.)?wikipedia.org$
+    - (.*\.)?github.com$
+    - (.*\.)?reddit.com$
+    - (.*\.)?docker.com$
+    - (.*\.)?archlinux.org$
+    - (.*\.)?stackoverflow.com$
+    - (.*\.)?askubuntu.com$
+    - (.*\.)?superuser.com$

--- a/kubernetes/apps/ai/searxng/ks.yaml
+++ b/kubernetes/apps/ai/searxng/ks.yaml
@@ -9,7 +9,6 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: searxng
-      namespace: ai
   interval: 30m
   path: ./kubernetes/apps/ai/searxng/app
   postBuild:

--- a/kubernetes/apps/ai/searxng/ks.yaml
+++ b/kubernetes/apps/ai/searxng/ks.yaml
@@ -9,8 +9,6 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: searxng
-  dependsOn:
-    - name: dragonfly
       namespace: ai
   interval: 30m
   path: ./kubernetes/apps/ai/searxng/app

--- a/kubernetes/apps/ai/searxng/ks.yaml
+++ b/kubernetes/apps/ai/searxng/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: searxng
+  namespace: ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: searxng
+  dependsOn:
+    - name: dragonfly
+      namespace: ai
+  interval: 30m
+  path: ./kubernetes/apps/ai/searxng/app
+  postBuild:
+    substitute:
+      APP: searxng
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

Add SearXNG meta-search engine to the ai namespace with:

- HelmRelease using app-template chart (2 replicas)
- Redis backend via dragonfly.database:6379
- External secrets for SEARXNG_SECRET (1Password)
- ConfigMap with custom settings.yml and limiter.toml
- Route via envoy-internal to search.oxygn.dev
- Security: readOnlyRootFilesystem, dropped capabilities, non-root user

## Files

- ks.yaml - Flux Kustomization
- app/ocirepository.yaml - app-template chart (tag 4.6.2)
- app/helmrelease.yaml - SearXNG deployment
- app/externalsecret.yaml - 1Password secret
- app/kustomization.yaml - ConfigMap + resources
- app/resources/limiter.toml - Rate limiting config
- app/resources/settings.yml - SearXNG settings

## TODO before merge

- [x] Secret added to 1Password vault (searxng item, SEARXNG_SECRET key)