### PR TITLE
fix(ai): add ocirepository to searxng kustomization

### DIFF
--- a/kubernetes/apps/ai/searxng/app/kustomization.yaml
+++ b/kubernetes/apps/ai/searxng/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./ocirepository.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
 configMapGenerator:


### PR DESCRIPTION
OCIRepository was not listed in kustomization.yaml resources, causing HelmRelease to fail with: could not get Source object: OCIRepository.source.toolkit.fluxcd.io "searxng" not found