### PR TITLE
fix(ai): add route rules to searxng HelmRelease

### DIFF
--- a/kubernetes/apps/ai/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/searxng/app/helmrelease.yaml
@@ -116,6 +116,10 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - name: searxng
+                port: *port
 
     service:
       app:


### PR DESCRIPTION
Helm install failed with: An explicit rule is required because automatic Service detection is not possible. (route: app). Added rules block to route.app spec.