### PR TITLE
fix(ai): update searxng image tag to 2026.4.22-74f1ca203

### DIFF
--- a/kubernetes/apps/ai/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/searxng/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           main:
             image:
               repository: docker.io/searxng/searxng
-              tag: 2024.6.30-39aaac40d
+              tag: 2026.4.22-74f1ca203
             env:
               SEARXNG_BASE_URL: https://search.oxygn.dev
               SEARXNG_PORT: &port 8080


### PR DESCRIPTION
Tag 2024.6.30-39aaac40d doesn't exist on Docker Hub. Updated to latest available: 2026.4.22-74f1ca203