### PR TITLE
fix(ai): add pod securityContext for redis sidecar

### DIFF
--- a/kubernetes/apps/ai/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/searxng/app/helmrelease.yaml
@@ -15,6 +15,10 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         strategy: RollingUpdate
+        pod:
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
 
         containers:
           main:


### PR DESCRIPTION
Redis container fails with: setpriv setresuid failed: Operation not permitted. Added pod-level securityContext with runAsUser: 65534 (nobody user) for the redis container to run properly.