### PR TITLE
fix(webhook): correct lobster pipeline path for devops-pr-gate

### DIFF
--- a/kubernetes/apps/self-hosted/webhook/app/resources/github.sh
+++ b/kubernetes/apps/self-hosted/webhook/app/resources/github.sh
@@ -171,7 +171,7 @@ fi
 if [[ "$IS_PR" == "true" && "$EVENT_TYPE" == "pull_request" ]]; then
     LOBSTER_MSG="PR #$NUMBER - $REPO_FULL_NAME
 
-Run lobster pipeline: lobster run --file ~/.openclaw/workspace/projects/openclaw-automatisation/pipelines/devops-pr-gate.lobster --args-json '{\"PR\":$NUMBER,\"REPO\":\"$REPO_FULL_NAME\"}'
+Run lobster pipeline: lobster run --file ~/.openclaw/workspace-devops/pipelines/devops-pr-gate.lobster --args-json '{\"PR\":$NUMBER,\"REPO\":\"$REPO_FULL_NAME\"}'
 
 PR Title: $TITLE
 PR Author: $USER


### PR DESCRIPTION
## Summary

- Le chemin envoyé par le script webhook à l'agent devops pointait vers `~/.openclaw/workspace/projects/openclaw-automatisation/pipelines/devops-pr-gate.lobster` (inexistant)
- Le chemin correct est `~/.openclaw/workspace-devops/pipelines/devops-pr-gate.lobster`
- Chaque événement PR GitHub déclenchait donc un `lobster run` contre un fichier introuvable

## Test plan

- [ ] Vérifier qu'un PR ouvert sur OxygnCorp/infra déclenche bien le pipeline et que l'agent devops reçoit les données CI/Flux/cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)