### PR TITLE
fix(flaresolverr): increase memory limit from 256Mi to 512Mi

### DIFF
--- a/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
                 cpu: 15m
                 memory: 192Mi
               limits:
-                memory: 256Mi
+                memory: 512Mi
                 cpu: 200m
     service:
       app:


### PR DESCRIPTION
## Description

FlareSolverr keeps getting OOMKilled (25 restarts, exit code 137) with its current 256Mi memory limit. Cloudflare challenges require more headroom — the pod typically runs for ~6h before hitting the limit.

## Changes

- Memory limit: `256Mi` → `512Mi` (request stays at `192Mi`)
- CPU limit unchanged: `200m`

## Testing

- Pod currently uses ~43Mi after restart, growing to ~256Mi over 6h
- 512Mi provides headroom for Cloudflare challenge spikes without waste