### PR TITLE
fix: increase CPU requests/limits for seerr and smartctl-exporter

### DIFF
--- a/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
                 cpu: 15m
                 memory: 192Mi
               limits:
-                memory: 256Mi
+                memory: 512Mi
                 cpu: 200m
     service:
       app:

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -54,11 +54,11 @@ spec:
               capabilities: { drop: ["ALL"] }
             resources:
               requests:
-                cpu: 10m
+                cpu: 100m
                 memory: 320Mi
               limits:
                 memory: 512Mi
-                cpu: 200m
+                cpu: 500m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
@@ -30,8 +30,8 @@ spec:
 
     resources:
       requests:
-        cpu: 100m
+        cpu: 200m
         memory: 128Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 256Mi


### PR DESCRIPTION
## Contexte

Les deux services sont chroniquement throttlés (CPUThrottlingHigh) depuis au moins 7 jours, malgré une consommation CPU réelle très basse (1-5m en moyenne).

| Service | Throttling | Conso réelle | Before |
|---------|-----------|-------------|--------|
| Seerr | **42%** des périodes throttlées | avg 5m, max 23m | req 10m / limit 200m |
| Smartctl-exporter ×3 | **~72%** des périodes throttlées | avg 1-2m | req 100m / limit 200m |

**Root cause :** CPU request trop bas → CFS scheduler throttle les containers dès qu'ils burst, même des bursts minimes.

## Changements

**Seerr :**
- Request CPU : `10m` → `100m`
- Limit CPU : `200m` → `500m`

**Smartctl-exporter :**
- Request CPU : `100m` → `200m`
- Limit CPU : `200m` → `500m`

## Impact ressources

Engagement supplémentaire total : ~300m CPU sur un cluster de 24 cores — négligeable.