### PR TITLE
feat: deploy toolhive with MCP servers in ai namespace

### DIFF
--- a/kubernetes/apps/ai/toolhive/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator
+  interval: 30m
+  values:
+    operator:
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      gc:
+        gomemlimit: 450MiB
+        gogc: 75

--- a/kubernetes/apps/ai/toolhive/app/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/app/kustomization.yaml
@@ -2,12 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/toolhive/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.26.1
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator

--- a/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/toolhive.stacklok.dev/embeddingserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: EmbeddingServer
+metadata:
+  name: mcp-tools-embedding
+spec:
+  model: sentence-transformers/all-MiniLM-L6-v2
+  image: ghcr.io/huggingface/text-embeddings-inference:cpu-latest@sha256:492506e6a76ce6d0fd834a49f69bee4134f5b37de06052519d358a3d5387434d
+  env:
+    - name: HOSTNAME
+      value: "::"

--- a/kubernetes/apps/ai/toolhive/config/httproute.yaml
+++ b/kubernetes/apps/ai/toolhive/config/httproute.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-gateway
+spec:
+  hostnames:
+    - mcp.oxygn.dev
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: vmcp-mcp-gateway-internal
+          port: 4483

--- a/kubernetes/apps/ai/toolhive/config/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/config/kustomization.yaml
@@ -2,12 +2,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./embeddingserver.yaml
+  - ./httproute.yaml
+  - ./mcp-telemetry.yaml
+  - ./mcpgroup.yaml
+  - ./podmonitor.yaml
+  - ./virtualmcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/config/mcp-telemetry.yaml
+++ b/kubernetes/apps/ai/toolhive/config/mcp-telemetry.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/toolhive.stacklok.dev/mcptelemetryconfig_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPTelemetryConfig
+metadata:
+  name: prometheus
+spec:
+  prometheus:
+    enabled: true

--- a/kubernetes/apps/ai/toolhive/config/mcpgroup.yaml
+++ b/kubernetes/apps/ai/toolhive/config/mcpgroup.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/toolhive.stacklok.dev/mcpgroup_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPGroup
+metadata:
+  name: mcp-tools
+spec:
+  description: Optimized MCP tools for AI assistants

--- a/kubernetes/apps/ai/toolhive/config/podmonitor.yaml
+++ b/kubernetes/apps/ai/toolhive/config/podmonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mcp-gateway-internal
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: virtualmcpserver
+      app.kubernetes.io/instance: mcp-gateway-internal
+  namespaceSelector:
+    matchNames:
+      - ai
+  podMetricsEndpoints:
+    - port: "8080"
+      path: /metrics
+      interval: 15s

--- a/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: VirtualMCPServer
+metadata:
+  name: mcp-gateway-internal
+spec:
+  groupRef:
+    name: mcp-tools
+  config:
+    aggregation:
+      conflictResolution: prefix
+      conflictResolutionConfig:
+        prefixFormat: "{workload}_"
+  embeddingServerRef:
+    name: mcp-tools-embedding
+  incomingAuth:
+    type: anonymous
+  outgoingAuth:
+    source: discovered

--- a/kubernetes/apps/ai/toolhive/crds/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/helmrelease.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator-crds
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator-crds
+  interval: 30m

--- a/kubernetes/apps/ai/toolhive/crds/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/kustomization.yaml
@@ -2,12 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/toolhive/crds/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator-crds
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.26.1
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -1,0 +1,225 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name toolhive-crds
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: toolhive-operator-crds
+      namespace: ai
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/crds
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name toolhive
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  dependsOn:
+    - name: toolhive-crds
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: toolhive-operator
+      namespace: ai
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/app
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name toolhive-config
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  components:
+    - ../../../../components/dragonfly
+  dependsOn:
+    - name: toolhive
+  healthCheckExprs:
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      failed: status.phase != 'ready'
+      current: status.phase == 'ready'
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/config
+  postBuild:
+    substitute:
+      APP: toolhive
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name arr-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  dependsOn:
+    - name: toolhive
+    - name: radarr
+      namespace: download
+    - name: sonarr
+      namespace: download
+    - name: prowlarr
+      namespace: download
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name grafana-mcp-entry
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  dependsOn:
+    - name: toolhive
+    - name: grafana-mcp
+      namespace: observability
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name ha-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  dependsOn:
+    - name: toolhive
+    - name: home-assistant
+      namespace: automation
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name memory-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  components:
+    - ../../../../../components/volsync
+  dependsOn:
+    - name: toolhive
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp
+  postBuild:
+    substitute:
+      APP: *name
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name seerr-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  dependsOn:
+    - name: toolhive
+    - name: seerr
+      namespace: media
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/externalsecret.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-sonarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
+  dataFrom:
+  - extract:
+      key: sonarr
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-radarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        RADARR_API_KEY: "{{ .RADARR_API_KEY }}"
+  dataFrom:
+  - extract:
+      key: radarr
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-prowlarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
+  dataFrom:
+  - extract:
+      key: prowlarr

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/kustomization.yaml
@@ -2,12 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: arr
+spec:
+  image: docker.io/node:24-alpine
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: HOME
+      value: /tmp
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/.npm
+    - name: SONARR_URL
+      value: http://sonarr.download
+    - name: RADARR_URL
+      value: http://radarr.download
+    - name: PROWLARR_URL
+      value: http://prowlarr.download
+  secrets:
+    - name: toolhive-sonarr
+      key: SONARR_API_KEY
+      targetEnvName: SONARR_API_KEY
+    - name: toolhive-radarr
+      key: RADARR_API_KEY
+      targetEnvName: RADARR_API_KEY
+    - name: toolhive-prowlarr
+      key: PROWLARR_API_KEY
+      targetEnvName: PROWLARR_API_KEY
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          image: docker.io/node:24-alpine
+          command:
+            - npx
+          args:
+            - -y
+            - mcp-arr-server@1.5.4
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp/kustomization.yaml
@@ -2,12 +2,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./mcpserverentry.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp/mcpserverentry.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp/mcpserverentry.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/toolhive.stacklok.dev/mcpserverentry_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServerEntry
+metadata:
+  name: grafana
+spec:
+  remoteUrl: http://grafana-mcp.observability:8000/sse
+  transport: sse
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-home-assistant
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        HOMEASSISTANT_TOKEN: "{{ .HASS_OPENCLAW_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: home-assistant

--- a/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/kustomization.yaml
@@ -2,12 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/mcpserver.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: ha-mcp
+spec:
+  image: ghcr.io/homeassistant-ai/ha-mcp:7.4.0
+  transport: streamable-http
+  groupRef:
+    name: mcp-tools
+  env:
+    - name: HOMEASSISTANT_URL
+      value: http://home-assistant.automation:8123
+  secrets:
+    - name: toolhive-home-assistant
+      key: HOMEASSISTANT_TOKEN
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          command:
+            - ha-mcp-web

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
@@ -2,12 +2,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./arr-mcp
+  - ./grafana-mcp
+  - ./ha-mcp
+  - ./memory-mcp
+  - ./seerr-mcp

--- a/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/kustomization.yaml
@@ -2,12 +2,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/mcpserver.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: &name memory-mcp
+spec:
+  image: ghcr.io/bjw-s-labs/mcp-memory:2026.1.26@sha256:df4a7e3709dfe363cd9048df13b2aed7f13ee135f07d07cd318d69f7e058abd8
+  transport: stdio
+  groupRef:
+    name: mcp-tools
+  podTemplateSpec:
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: *name
+      containers:
+        - name: mcp
+          volumeMounts:
+            - name: data
+              mountPath: /data

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-seerr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        SEERR_API_KEY: "{{ .SEERR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: seerr

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/kustomization.yaml
@@ -2,12 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  # - ./openclaw/ks.yaml
-  - ./searxng/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/mcpserver.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: seerr-mcp
+spec:
+  image: docker.io/node:24-alpine
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: HOME
+      value: /tmp
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/.npm
+    - name: SEERR_URL
+      value: http://seerr.media
+  secrets:
+    - name: toolhive-seerr
+      key: SEERR_API_KEY
+      targetEnvName: SEERR_API_KEY
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          image: docker.io/node:24-alpine
+          command:
+            - npx
+          args:
+            - -y
+            - "@jhomen368/overseerr-mcp"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/components/dragonfly/cluster.yaml
+++ b/kubernetes/components/dragonfly/cluster.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: ${APP}-dragonfly
+spec:
+  image: ghcr.io/dragonflydb/dragonfly:v1.38.1
+  replicas: ${DRAGONFLY_REPLICAS:=2}
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+  args:
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+    - --cluster_mode=emulated
+  resources:
+    requests:
+      cpu: 25m
+    limits:
+      memory: 768Mi
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: "kubernetes.io/hostname"
+      whenUnsatisfiable: "DoNotSchedule"
+      nodeTaintsPolicy: Honor
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/part-of: dragonfly

--- a/kubernetes/components/dragonfly/kustomization.yaml
+++ b/kubernetes/components/dragonfly/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/component.json
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cluster.yaml
+  - ./networkpolicy-prometheus-metrics.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/components/dragonfly/networkpolicy-prometheus-metrics.yaml
+++ b/kubernetes/components/dragonfly/networkpolicy-prometheus-metrics.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${APP}-dragonfly-prometheus-metrics
+spec:
+  podSelector:
+    matchLabels:
+      app: ${APP}-dragonfly
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 9999

--- a/kubernetes/components/dragonfly/podmonitor.yaml
+++ b/kubernetes/components/dragonfly/podmonitor.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${APP}-dragonfly
+spec:
+  selector:
+    matchLabels:
+      app: ${APP}-dragonfly
+  podTargetLabels:
+    - app
+  podMetricsEndpoints:
+    - port: admin
+  fallbackScrapeProtocol: PrometheusText0.0.4


### PR DESCRIPTION
Add toolhive operator, CRDs, and configuration with 5 MCP servers (arr, grafana, ha, memory, seerr). Includes dragonfly component for caching and volsync for memory-mcp backups.