### PR TITLE
fix(webhook): remove reopened/synchronize triggers, keep only opened

### DIFF
--- a/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
                 cpu: 15m
                 memory: 192Mi
               limits:
-                memory: 256Mi
+                memory: 512Mi
                 cpu: 200m
     service:
       app:

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -54,11 +54,11 @@ spec:
               capabilities: { drop: ["ALL"] }
             resources:
               requests:
-                cpu: 10m
+                cpu: 100m
                 memory: 320Mi
               limits:
                 memory: 512Mi
-                cpu: 200m
+                cpu: 500m
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
@@ -30,8 +30,8 @@ spec:
 
     resources:
       requests:
-        cpu: 100m
+        cpu: 200m
         memory: 128Mi
       limits:
-        cpu: 200m
+        cpu: 500m
         memory: 256Mi

--- a/kubernetes/apps/self-hosted/webhook/app/resources/github.sh
+++ b/kubernetes/apps/self-hosted/webhook/app/resources/github.sh
@@ -168,7 +168,7 @@ fi
 # Si c'est un PR (pas un review), on envoie un message directive pour lobster
 # avec deliver=false pour que l'agent isolé exécute le pipeline
 
-if [[ "$IS_PR" == "true" && "$EVENT_TYPE" == "pull_request" ]]; then
+if [[ "$IS_PR" == "true" && "$EVENT_TYPE" == "pull_request" && "$ACTION" == "opened" ]]; then
     LOBSTER_MSG="PR #$NUMBER - $REPO_FULL_NAME
 
 Run lobster pipeline: lobster run --file ~/.openclaw/workspace-devops/pipelines/devops-pr-gate.lobster --args-json '{\"PR\":$NUMBER,\"REPO\":\"$REPO_FULL_NAME\"}'

--- a/kubernetes/apps/self-hosted/webhook/app/resources/github.sh
+++ b/kubernetes/apps/self-hosted/webhook/app/resources/github.sh
@@ -209,7 +209,15 @@ PR Action: $ACTION"
 
     echo "Sending PR to lobster pipeline: $REPO_FULL_NAME #$NUMBER" >&2
 else
-    # Pour les issues et reviews, garder le comportement actuel (deliver=true)
+    # Supprimer le deliver pour les events PR non-opened (labeled, synchronize, etc.)
+    # pour éviter les doublons avec le message PR Gate.
+    # Garder deliver pour les issues et reviews.
+    if [[ "$IS_PR" == "true" && "$EVENT_TYPE" == "pull_request" ]]; then
+        DELIVER=false
+    else
+        DELIVER=true
+    fi
+
     PAYLOAD_JSON=$(jq -n \
         --arg msg "$CONTEXT_MSG" \
         --arg repo "$REPO_FULL_NAME" \
@@ -219,12 +227,13 @@ else
         --arg title "$TITLE" \
         --arg sender "$SENDER" \
         --arg assignee "$ASSIGNEE" \
+        --argjson deliver "$DELIVER" \
         '{
             "message": $msg,
             "name": "GitHub",
             "agentId": "devops",
             "wakeMode": "now",
-            "deliver": true,
+            "deliver": $deliver,
             "channel": "discord",
             "thinking": "medium",
             "timeoutSeconds": 300,

--- a/kubernetes/apps/self-hosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/self-hosted/webhook/app/resources/hooks.yaml
@@ -261,34 +261,6 @@
                   parameter:
                     source: payload
                     name: action
-          - # Trigger on pull request REOPENED events (reopened closed PRs)
-            and:
-              - match:
-                  type: value
-                  value: pull_request
-                  parameter:
-                    source: header
-                    name: x-github-event
-              - match:
-                  type: value
-                  value: reopened
-                  parameter:
-                    source: payload
-                    name: action
-          - # Trigger on pull request SYNCHRONIZE events (new commits pushed to existing PRs)
-            and:
-              - match:
-                  type: value
-                  value: pull_request
-                  parameter:
-                    source: header
-                    name: x-github-event
-              - match:
-                  type: value
-                  value: synchronize
-                  parameter:
-                    source: payload
-                    name: action
           - # Trigger on pull request review events (approvals)
             and:
               - match:

--- a/kubernetes/apps/self-hosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/self-hosted/webhook/app/resources/hooks.yaml
@@ -247,48 +247,6 @@
                   parameter:
                     source: payload
                     name: pull_request.assignee.login
-          - # Trigger on pull request OPENED events (new PRs)
-            and:
-              - match:
-                  type: value
-                  value: pull_request
-                  parameter:
-                    source: header
-                    name: x-github-event
-              - match:
-                  type: value
-                  value: opened
-                  parameter:
-                    source: payload
-                    name: action
-          - # Trigger on pull request REOPENED events (reopened closed PRs)
-            and:
-              - match:
-                  type: value
-                  value: pull_request
-                  parameter:
-                    source: header
-                    name: x-github-event
-              - match:
-                  type: value
-                  value: reopened
-                  parameter:
-                    source: payload
-                    name: action
-          - # Trigger on pull request SYNCHRONIZE events (new commits pushed to existing PRs)
-            and:
-              - match:
-                  type: value
-                  value: pull_request
-                  parameter:
-                    source: header
-                    name: x-github-event
-              - match:
-                  type: value
-                  value: synchronize
-                  parameter:
-                    source: payload
-                    name: action
           - # Trigger on pull request review events (approvals)
             and:
               - match:

--- a/kubernetes/apps/self-hosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/self-hosted/webhook/app/resources/hooks.yaml
@@ -247,6 +247,48 @@
                   parameter:
                     source: payload
                     name: pull_request.assignee.login
+          - # Trigger on pull request OPENED events (new PRs)
+            and:
+              - match:
+                  type: value
+                  value: pull_request
+                  parameter:
+                    source: header
+                    name: x-github-event
+              - match:
+                  type: value
+                  value: opened
+                  parameter:
+                    source: payload
+                    name: action
+          - # Trigger on pull request REOPENED events (reopened closed PRs)
+            and:
+              - match:
+                  type: value
+                  value: pull_request
+                  parameter:
+                    source: header
+                    name: x-github-event
+              - match:
+                  type: value
+                  value: reopened
+                  parameter:
+                    source: payload
+                    name: action
+          - # Trigger on pull request SYNCHRONIZE events (new commits pushed to existing PRs)
+            and:
+              - match:
+                  type: value
+                  value: pull_request
+                  parameter:
+                    source: header
+                    name: x-github-event
+              - match:
+                  type: value
+                  value: synchronize
+                  parameter:
+                    source: payload
+                    name: action
           - # Trigger on pull request review events (approvals)
             and:
               - match:


### PR DESCRIPTION
## Problème

Les notifications PR Gate arrivaient en double malgré le filtre `ACTION == "opened"` dans `github.sh` et le `DELIVER=false` pour les events PR non-opened.

**Cause :** Les triggers `pull_request reopened` et `pull_request synchronize` dans `hooks.yaml` appelaient `github.sh` avec un message contenant "Run lobster pipeline". Ce message réveillait l'agent devops (via `deliver: false`) qui pouvait relancer la pipeline une seconde fois, générant un second message PR Gate.

## Fix

Suppression des triggers `reopened` et `synchronize` dans le hook `github-oxygn-bot`.

**Conservés :**
- `pull_request assigned` — assignation à puchu-ai
- `pull_request opened` — **indispensable** pour le PR Gate
- `pull_request review` — approvals

**Description des changements :**
- Suppression de 28 lignes dans `hooks.yaml`