### PR TITLE
feat: add oikos family planner deployment

### DIFF
--- a/kubernetes/apps/self-hosted/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../components/alerts
 
 resources:
+  - ./oikos/ks.yaml
   - ./namespace.yaml
   - ./actual/ks.yaml
   - ./convertx/ks.yaml

--- a/kubernetes/apps/self-hosted/oikos/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oikos
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: oikos
+    template:
+      data:
+        SESSION_SECRET: "{{ .SESSION_SECRET }}"
+        DB_ENCRYPTION_KEY: "{{ .DB_ENCRYPTION_KEY }}"
+  dataFrom:
+    - extract:
+        key: oikos

--- a/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
@@ -1,0 +1,115 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: oikos
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: oikos
+  interval: 1h
+  values:
+    controllers:
+      oikos:
+        replicas: 1
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ulsklyc/oikos
+              tag: latest
+              pullPolicy: Always
+            env:
+              TZ: Europe/Paris
+              NODE_ENV: production
+              DB_PATH: /data/oikos.db
+              BACKUP_DIR: /backups
+              SESSION_SECURE: "false"
+            envFrom:
+              - secretRef:
+                  name: oikos
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 10
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+        pod:
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            fsGroup: 65534
+            fsGroupChangePolicy: OnRootMismatch
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+    service:
+      app:
+        controller: oikos
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - oikos.oxygn.dev
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      data:
+        enabled: true
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /data
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          oikos:
+            app:
+              - path: /backups
+                subPath: backups
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/self-hosted/oikos/app/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/self-hosted/oikos/app/ocirepository.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: oikos
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/self-hosted/oikos/ks.yaml
+++ b/kubernetes/apps/self-hosted/oikos/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oikos
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: oikos
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/self-hosted/oikos/app
+  postBuild:
+    substitute:
+      APP: oikos
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: self-hosted
+  wait: false


### PR DESCRIPTION
Deploie Oikos (https://github.com/ulsklyc/oikos) sur le cluster.

- Flux Kustomization avec volsync pour les backups
- HelmRelease via bjw-s app-template chart
- ExternalSecret pour les clés (1Password item 'oikos' à créer)
- Route: oikos.oxygn.dev via envoy-internal
- PVC 5Gi ceph-block pour la base SQLite