### PR TITLE
fix(oikos): correct pod securityContext for node user

### DIFF
--- a/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
@@ -16,6 +16,18 @@ spec:
         strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          fix-permissions:
+            image:
+              repository: ghcr.io/ulsklyc/oikos
+              tag: latest
+            command: ["chown", "-R", "1000:1000", "/data"]
+            securityContext:
+              runAsUser: 0
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
         containers:
           app:
             image:
@@ -78,9 +90,9 @@ spec:
                   - ALL
         pod:
           securityContext:
-            runAsUser: 65534
-            runAsGroup: 65534
-            fsGroup: 65534
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
             fsGroupChangePolicy: OnRootMismatch
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
Fix du crashloop sur Oikos : le conteneur utilisait UID 65534 mais le node user du Dockerfile est UID 1000.

- Pod securityContext : runAsUser/runAsGroup/fsGroup = 1000
- InitContainer en root pour chown le volume avant le démarrage
- Le entrypoint.sh du conteneur attend ces permissions