### PR TITLE
fix(oikos): override entrypoint to skip chown/gosu

### DIFF
--- a/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
@@ -22,6 +22,7 @@ spec:
               repository: ghcr.io/ulsklyc/oikos
               tag: latest
               pullPolicy: Always
+            command: ["node", "server/index.js"]
             env:
               TZ: Europe/Paris
               NODE_ENV: production


### PR DESCRIPTION
Skip l'entrypoint.sh qui fait chown + gosu → nécessite des droits root.

On lance directement `node server/index.js`. Les permissions du volume sont gérées par fsGroup + OnRootMismatch côté K8s.