### PR TITLE
fix(oikos): switch to envoy-external for Google Calendar OAuth

### DIFF
--- a/kubernetes/apps/self-hosted/oikos/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/externalsecret.yaml
@@ -15,6 +15,9 @@ spec:
       data:
         SESSION_SECRET: "{{ .SESSION_SECRET }}"
         DB_ENCRYPTION_KEY: "{{ .DB_ENCRYPTION_KEY }}"
+        GOOGLE_CLIENT_ID: "{{ .GOOGLE_CLIENT_ID }}"
+        GOOGLE_CLIENT_SECRET: "{{ .GOOGLE_CLIENT_SECRET }}"
+        GOOGLE_REDIRECT_URI: "{{ .GOOGLE_REDIRECT_URI }}"
   dataFrom:
     - extract:
         key: oikos

--- a/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
         hostnames:
           - oikos.oxygn.dev
         parentRefs:
-          - name: envoy-internal
+          - name: envoy-external
             namespace: network
     persistence:
       data:


### PR DESCRIPTION
Google Calendar OAuth nécessite que Google puisse rediriger vers le callback URL.

- Passage de  à  (IP publique 10.10.98.250)
- Ajout des vars GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI
  dans le ExternalSecret (via l'item 1Password `oikos`)