### PR TITLE
feat(nextcloud): add Nextcloud deployment on Kubernetes

### DIFF
--- a/kubernetes/apps/self-hosted/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 resources:
   - ./oikos/ks.yaml
   - ./namespace.yaml
+  - ./nextcloud/ks.yaml
   - ./actual/ks.yaml
   - ./convertx/ks.yaml
   - ./mealie/ks.yaml

--- a/kubernetes/apps/self-hosted/nextcloud/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/nextcloud/app/externalsecret.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nextcloud-admin
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: nextcloud-secret
+    template:
+      data:
+        username: "{{ .username }}"
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: nextcloud
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nextcloud-db
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: nextcloud-db-secret
+    template:
+      data:
+        username: "{{ .db-username }}"
+        password: "{{ .db-password }}"
+  dataFrom:
+    - extract:
+        key: nextcloud

--- a/kubernetes/apps/self-hosted/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nextcloud/app/helmrelease.yaml
@@ -1,0 +1,136 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nextcloud
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: nextcloud
+  interval: 1h
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      flavor: fpm-alpine
+
+    nginx:
+      enabled: true
+
+    nextcloud:
+      datadir: /var/www/data
+      host: &host nextcloud.oxygn.dev
+      existingSecret:
+        enabled: true
+        secretName: nextcloud-secret
+        usernameKey: username
+        passwordKey: password
+      mail:
+        enabled: false
+      configs:
+        proxy.config.php: |-
+          <?php
+          $CONFIG = array (
+            'check_data_directory_permissions' => false,
+            'forwarded_for_headers' => array('HTTP_X_FORWARDED_FOR'),
+            'mail_smtpmode' => 'null',
+            'skeletondirectory' => '',
+            'trusted_proxies' => array(
+              0 => '127.0.0.1',
+              1 => '10.244.0.0/16',
+            ),
+          ); ?>
+        misc.config.php: |-
+          <?php
+          $CONFIG = array (
+            'default_phone_region' => 'FR',
+            'maintenance_window_start' => 2,
+          ); ?>
+
+    externalDatabase:
+      enabled: true
+      type: postgresql
+      host: postgres-rw.database.svc.cluster.local
+      database: nextcloud
+      existingSecret:
+        enabled: true
+        secretName: nextcloud-db-secret
+        usernameKey: username
+        passwordKey: password
+
+    externalRedis:
+      enabled: true
+      host: nextcloud-dragonfly
+      port: 6379
+
+    cronjob:
+      type: cronjob
+      enabled: true
+      cronjob:
+        affinity:
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/instance
+                      operator: In
+                      values:
+                        - nextcloud
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                        - app
+                topologyKey: kubernetes.io/hostname
+        successfulJobsHistoryLimit: 1
+
+    httpRoute:
+      enabled: true
+      hostnames:
+        - *host
+      parentRefs:
+        - name: envoy-external
+          namespace: network
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: "/"
+          filters:
+            - type: ResponseHeaderModifier
+              responseHeaderModifier:
+                add:
+                  - name: strict-transport-security
+                    value: max-age=31536000
+
+    persistence:
+      enabled: true
+      existingClaim: nextcloud
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: nextcloud
+            patch: |-
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: nextcloud
+              spec:
+                template:
+                  spec:
+                    hostUsers: false

--- a/kubernetes/apps/self-hosted/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nextcloud/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
             'skeletondirectory' => '',
             'trusted_proxies' => array(
               0 => '127.0.0.1',
-              1 => '10.244.0.0/16',
+              1 => '10.42.0.0/16',
             ),
           ); ?>
         misc.config.php: |-

--- a/kubernetes/apps/self-hosted/nextcloud/app/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/nextcloud/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/self-hosted/nextcloud/app/ocirepository.yaml
+++ b/kubernetes/apps/self-hosted/nextcloud/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nextcloud
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 9.1.0
+  url: oci://ghcr.io/nextcloud/helm/nextcloud

--- a/kubernetes/apps/self-hosted/nextcloud/ks.yaml
+++ b/kubernetes/apps/self-hosted/nextcloud/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.oxygn.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: nextcloud
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: nextcloud
+  components:
+    - ../../../../components/volsync
+    - ../../../../components/dragonfly
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/self-hosted/nextcloud/app
+  postBuild:
+    substitute:
+      APP: nextcloud
+      VOLSYNC_CAPACITY: 10Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: self-hosted
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/self-hosted/oikos/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/externalsecret.yaml
@@ -15,6 +15,9 @@ spec:
       data:
         SESSION_SECRET: "{{ .SESSION_SECRET }}"
         DB_ENCRYPTION_KEY: "{{ .DB_ENCRYPTION_KEY }}"
+        GOOGLE_CLIENT_ID: "{{ .GOOGLE_CLIENT_ID }}"
+        GOOGLE_CLIENT_SECRET: "{{ .GOOGLE_CLIENT_SECRET }}"
+        GOOGLE_REDIRECT_URI: "{{ .GOOGLE_REDIRECT_URI }}"
   dataFrom:
     - extract:
         key: oikos

--- a/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/oikos/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
         hostnames:
           - oikos.oxygn.dev
         parentRefs:
-          - name: envoy-internal
+          - name: envoy-external
             namespace: network
     persistence:
       data:


### PR DESCRIPTION
## Description

Déploiement de Nextcloud sur le cluster via la chart Helm communautaire `nextcloud/nextcloud` v9.1.0 (Nextcloud 33.0.3).

### Configuration

- **Image:** `fpm-alpine` + nginx sidecar
- **Base de données:** PostgreSQL via CNPG (`postgres-rw.database.svc.cluster.local`)
- **Cache Redis:** Dragonfly instance dédiée (`nextcloud-dragonfly`)
- **Stockage:** VolSync (PVC 10Gi)
- **Domaine:** nextcloud.oxygn.dev
- **Routage:** envoy-external (HTTPRoute)
- **Secrets:** ExternalSecrets depuis 1Password

### 🔑 Secrets 1Password nécessaires

L'item `nextcloud` (vault `home-ops`) doit contenir :
| Field | Description |
|-------|-------------|
| `username` | Admin Nextcloud |
| `password` | Mot de passe admin |
| `db-username` | Utilisateur PostgreSQL |
| `db-password` | Mot de passe PostgreSQL |

### Database à créer

Créer la base et l'utilisateur sur le cluster CNPG :
- Database: `nextcloud`
- User: `nextcloud` (mot de passe depuis 1Password)

### Checklist

- [x] Fichiers de déploiement créés
- [x] ExternalSecrets configurés
- [ ] Base de données PostgreSQL créée
- [ ] Review Matt