### PR TITLE
fix(nextcloud): cronjob securityContext + failedJobsHistoryLimit

### DIFF
--- a/kubernetes/apps/self-hosted/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nextcloud/app/helmrelease.yaml
@@ -91,6 +91,7 @@ spec:
           runAsUser: 82
           runAsGroup: 82
         successfulJobsHistoryLimit: 1
+        failedJobsHistoryLimit: 1
 
     httpRoute:
       enabled: true

--- a/kubernetes/apps/self-hosted/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nextcloud/app/helmrelease.yaml
@@ -87,6 +87,9 @@ spec:
                       values:
                         - app
                 topologyKey: kubernetes.io/hostname
+        securityContext:
+          runAsUser: 82
+          runAsGroup: 82
         successfulJobsHistoryLimit: 1
 
     httpRoute:


### PR DESCRIPTION
## Correctif cronjobs Nextcloud

### Problème
Les cronjobs Nextcloud échouent avec :
```
Console has to be executed with the user that owns the file config/config.php.
Current user id: 0
Owner id of config.php: 82
```

### Cause
Le conteneur cron tourne en root (uid 0) mais `config.php` appartient à www-data (uid 82). Nextcloud refuse d'exécuter `occ` par un utilisateur différent du propriétaire du fichier.

### Fix
1. Ajout de `securityContext.runAsUser: 82 / runAsGroup: 82` sur le cronjob
2. Ajout de `failedJobsHistoryLimit: 1` pour éviter l'accumulation des Error pods

### Commits
- feddcee6 — fix(nextcloud): set cronjob securityContext to run as www-data
- 69f24f41 — fix(nextcloud): limit failed cronjob history to 1