### PR TITLE
fix(ha-mcp): add emptyDir volume for /tmp to fix CrashLoopBackOff

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/mcpserver.yaml
@@ -21,3 +21,9 @@ spec:
         - name: mcp
           command:
             - ha-mcp-web
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Problem

Le pod ha-mcp est en CrashLoopBackOff à cause de cette erreur :



Python a besoin d'écrire dans /tmp (tempfile), mais le conteneur a `readOnlyRootFilesystem: true` sans volume writable monté sur /tmp.

## Solution

Ajout d'un emptyDir volume monté sur /tmp pour fournir un espace temporaire writable.

## Changement

```diff
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
```