### PR TITLE
fix(webhook): route PR webhooks through /hooks/pr-gate for mapping interception

### DIFF
--- a/kubernetes/apps/self-hosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/self-hosted/webhook/app/resources/hooks.yaml
@@ -129,7 +129,7 @@
   pass-arguments-to-command:
     - # OpenClaw webhook URL
       source: string
-      name: http://10.10.10.18:18789/hooks/agent
+      name: http://10.10.10.18:18789/hooks/pr-gate
     - # Full payload JSON
       source: entire-payload
   trigger-rule:


### PR DESCRIPTION
## Problème

Le webhook GitHub envoyait ses requêtes à `/hooks/agent` sur le gateway OpenClaw. Ce path est géré par un **dispatch agent built-in** qui s'exécute avant la vérification des `hooks.mappings`. Résultat : la mapping avec transform module n'était jamais atteinte, le pipeline lobster n'était pas déclenché.

## Solution

Changer l'URL du webhook vers `/hooks/pr-gate` — un path non réservé qui laisse les mappings s'exécuter.

### Flux après déploiement

1. GitHub envoie le webhook → `webhook.oxygn.dev/hooks/github-oxygn-bot`
2. Webhook daemon exécute `github.sh` → envoie à `POST /hooks/pr-gate`
3. Gateway ne reconnaît pas `pr-gate` comme wake/agent → **passe aux mappings**
4. Mapping intercepte → exécute le transform module `github-pr-gate.js`
5. Transform parse `LOBSTER_RUN` → spawn `lobster run` en detached
6. La pipeline PR gate tourne et gère Discord via `openclaw.invoke`

### PR liée

Cette PR est la dernière pièce du puzzle. Il faudra aussi **restart le gateway OpenClaw** après merge pour que le changement de path dans les mappings soit pris en compte.

## Checklist

- [x] hooks.yaml : URL changée dans `github-oxygn-bot`
- [x] Gateway : mapping path mis à jour (`/pr-gate`)
- [x] Transform module `github-pr-gate.js` déployé
- [x] Symlink `~/.openclaw/hooks/transforms → hooks-transforms/` en place
- [ ] **Restart gateway** après acceptation de la PR
