### PR TITLE
fix(mcp-tools-embedding): add CPU/RAM limits

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
@@ -10,3 +10,10 @@ spec:
   env:
     - name: HOSTNAME
       value: "::"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 1Gi


### PR DESCRIPTION
## Problème

`mcp-tools-embedding` avait **aucune resource limit** définie. Au pic, le pod consommait **1.8 CPU** sur k8s-0 (déjà à 99% avec 79 pods). Ça a déclenché une cascade :

1. k8s-0 saturé → API server lent → Prometheus scrape en retard
2. Prometheus lit massivement ses TSDB sur Ceph (305-399 MiB/s)
3. Ceph saturé → OSD lent → NodeDiskIOSaturation sur tous les nœuds

## Solution

Ajout de requests/limits sur `EmbeddingServer` :

| Ressource | Request | Limit |
|-----------|---------|-------|
| CPU | 100m | 2 |
| RAM | 512Mi | 1Gi |

Values basées sur l'idle constaté (10m CPU / 368Mi RAM) avec une marge suffisante pour les pics (1.8 CPU constaté).

## Checklist

- [x] Champs `resources` supportés par le CRD `EmbeddingServer` (toolhive)
- [x] Idle actuel : 10m CPU / 368Mi RAM
- [x] Pic constaté : 1.8 CPU
