### PR TITLE
fix(ai): wire ToolHive vmcp telemetry to Prometheus

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/podmonitor.yaml
+++ b/kubernetes/apps/ai/toolhive/config/podmonitor.yaml
@@ -15,6 +15,6 @@ spec:
     matchNames:
       - ai
   podMetricsEndpoints:
-    - port: "8080"
+    - port: http
       path: /metrics
       interval: 15s

--- a/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
@@ -13,6 +13,8 @@ spec:
         prefixFormat: "{workload}_"
   embeddingServerRef:
     name: mcp-tools-embedding
+  telemetryConfigRef:
+    name: prometheus
   incomingAuth:
     type: anonymous
   outgoingAuth:


### PR DESCRIPTION
## Summary

Fix ToolHive VirtualMCPServer (`mcp-gateway-internal`) telemetry so Prometheus can scrape `/metrics` from the vMCP gateway pod.

## Root cause

Two complementary bugs in `kubernetes/apps/ai/toolhive/config/` (kustomization `toolhive-config`):

1. **VirtualMCPServer had no `telemetryConfigRef`.** The `MCPTelemetryConfig/prometheus` resource exists with `spec.prometheus.enabled: true`, but the VirtualMCPServer never referenced it, so the ToolHive operator did not wire Prometheus into the generated vMCP deployment — the metrics endpoint was simply not present on the pod.
2. **PodMonitor scraped the wrong port.** It targeted `port: 8080`, but the operator generates a pod whose metrics endpoint is on the named port `http` (containerPort 4483, same as the service port `vmcp-mcp-gateway-internal:http`). Even if (1) had been in place, the PodMonitor would have been scraping nothing.

## Fix

| File | Change |
|---|---|
| `kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml` | Add `spec.telemetryConfigRef.name: prometheus` |
| `kubernetes/apps/ai/toolhive/config/podmonitor.yaml` | Change `podMetricsEndpoints[0].port` from `"8080"` to `http` |

## Validation

- `kubectl kustomize kubernetes/apps/ai/toolhive/config/` → renders all 8 resources cleanly
- `kubectl apply --dry-run=server -f -` → all resources validate, including the new `telemetryConfigRef` against the live CRD schema (`kubectl explain virtualmcpserver.spec.telemetryConfigRef`)
- Confirmed pod exposes `containerPort=4483, name=http` and service `vmcp-mcp-gateway-internal` exposes `port=4483, name=http`
- Confirmed `flux get kustomizations -A` shows `toolhive-config` Ready at `refs/heads/main@sha1:7082fe3c` (matches our local main)

## Expected result after merge

- The ToolHive operator will inject the Prometheus listener into the vMCP deployment on the next reconcile.
- `kube-prometheus-stack` Prometheus will start scraping `/metrics` from `mcp-gateway-internal-*` pods on port `http` (4483).
- New `thv_*` / OTel metrics from the vMCP gateway will appear in Prometheus and the existing `toolhive-mcp-gateway` Grafana dashboard.

## Out of scope

- The `toolhive.stacklok.dev/v1alpha1` deprecation warning seen on `embeddingserver` / `mcpgroup` / `mcptelemetryconfig` is preexisting and unrelated to this fix. Bumping those to `v1beta1` is a separate concern.

## Checklist

- [x] kustomize build clean
- [x] server-side dry-run clean
- [x] only 2 files touched
- [x] branch pushed, no direct merge — awaiting `devops-pr-gate` approval
