### PR TITLE
fix(kubectl-mcp): correct ClusterRoleBinding subject namespace (was `llm`, should be `ai`)

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/rbac.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/rbac.yaml
@@ -146,4 +146,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubectl-mcp-readonly
-    namespace: llm
+    namespace: ai


### PR DESCRIPTION
## Summary

Fix a broken `ClusterRoleBinding` that left the `kubectl-mcp` service account with **zero effective permissions** in the cluster.

## Root cause

The `ClusterRoleBinding` referenced the `kubectl-mcp-readonly` ServiceAccount in namespace `llm`, but the ServiceAccount is actually created in namespace `ai` (where the `MCPServer` is deployed).

The `llm` namespace **does not exist** in the cluster. The binding therefore matched no subject, and the SA inherited only the unauthenticated default — no rights to any resource.

## Evidence

Running the MCP tools before the fix produced 403 Forbidden on every operation, with errors explicitly naming the SA in namespace `ai` (e.g.):

```
(403) Reason: Forbidden
namespaces is forbidden: User "system:serviceaccount:ai:kubectl-mcp-readonly"
    cannot list resource "namespaces" in API group "" at the cluster scope
```

The actual `ClusterRoleBinding` in-cluster (inspected via shell `kubectl`):

```yaml
subjects:
  - kind: ServiceAccount
    name: kubectl-mcp-readonly
    namespace: llm    # ❌ wrong — should be `ai`
```

And the ServiceAccount that actually exists in the cluster:

```
$ kubectl get sa --all-namespaces | grep kubectl-mcp
ai   kubectl-mcp-readonly   8d
```

## What this PR changes

A single line in `kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/rbac.yaml`:

```diff
 subjects:
   - kind: ServiceAccount
     name: kubectl-mcp-readonly
-    namespace: llm
+    namespace: ai
```

The `ClusterRole` definition is left untouched — it is already comprehensive (≈ built-in `view` plus `pods/log`, plus explicit allow-listing of every CRD group in the cluster, plus an `aggregationRule` that automatically picks up any operator shipping `aggregate-to-view: "true"` labels).

## Impact

After Flux reconciles:

- `toolhive__kubectl_get_namespaces` → returns the full list (currently 403)
- `toolhive__kubectl_get_pods` → works in every namespace
- `toolhive__kubectl_get_crds` → works
- `toolhive__kubectl_health_check` → works
- `toolhive__kubectl_cilium_status_tool` → works (needs pods/log in kube-system)
- `toolhive__kubectl_certs_list_tool` → works (cert-manager is installed)
- …and effectively all 113 kubectl-mcp tools become operational

## Risk

Minimal. This is a one-line configuration correction that brings the binding in line with the actual ServiceAccount location. The `ClusterRole` itself is unchanged, so there is no privilege escalation — only activation of permissions that the original author clearly intended to grant.

## Verification plan

1. Merge the PR.
2. Wait for Flux to reconcile (interval 1h, or force with `flux reconcile kustomization ai`).
3. From a session with the kubectl-mcp tool, run `kubectl_get_namespaces` — should return the full namespace list.
4. Spot-check `kubectl_get_pods -n kube-system` to confirm `cilium` and `certs` MCP tools light up.

🤖 Generated with the help of an AI agent (Puchu)