### PR TITLE
fix(download): bump flaresolverr memory limit to 1Gi to prevent OOM

### DIFF
--- a/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/download/flaresolverr/app/helmrelease.yaml
@@ -22,9 +22,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 192Mi
+                memory: 256Mi
               limits:
-                memory: 512Mi
+                memory: 1Gi
                 cpu: 200m
     service:
       app:


### PR DESCRIPTION
## Summary

Bump FlareSolverr memory limits in the `download` namespace to eliminate the OOM risk we are sitting on right now.

## Why

FlareSolverr embeds headless Chromium, which is memory-hungry. The current limit (`512Mi`) is too tight for steady operation.

Evidence (Prometheus / cAdvisor, 30-day window):

| Metric | Value | Notes |
|---|---|---|
| `max_over_time(container_memory_working_set_bytes)` peak | **535 MiB** | Right at the 512Mi limit |
| `container_memory_working_set_bytes` (now) | ~161 MiB | Idle baseline |
| `kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}` | 0 changes | No OOMKill *yet* — pure luck |
| Pod logs (last 24h) | 1× Cloudflare challenge timed out at 79s | 60s default + Chromium churn |
| Other `download/` apps peak | sonarr 277Mi, radarr 306Mi, sabnzbd 208Mi | FlareSolverr is by far the heaviest |

A single concurrent challenge or a longer Cloudflare flow puts working set over 512Mi and triggers OOM. This is a *when*, not *if*.

## Change

`kubernetes/apps/download/flaresolverr/app/helmrelease.yaml`

```diff
             resources:
               requests:
                 cpu: 15m
-                memory: 192Mi
+                memory: 256Mi
               limits:
-                memory: 512Mi
+                memory: 1Gi
                 cpu: 200m
```

- `limits.memory`: **512Mi → 1Gi** (×2, healthy headroom for Chromium)
- `requests.memory`: **192Mi → 256Mi** (small QoS-aligned bump; QoS class stays `Burstable`)
- CPU unchanged (peak CPU is well below the 200m cap)

## Validation

- `mise exec -- flate test hr --path ./kubernetes/apps/download/flaresolverr` → **1 passed, 0 failed**
- `mise exec -- flate diff hr --path ./kubernetes/apps/download/flaresolverr --path-orig <main>` → only the two expected value changes
- CI (`flate.yaml` workflow) will re-run on this PR

## Rollout

Flux will reconcile the HelmRelease on its 1h interval. The Deployment uses `strategyType: Recreate`, so there is a brief 5–10s downtime window when the pod restarts. Acceptable for a non-user-facing helper (only Prowlarr/Sonarr/Radarr/Sabnzbd hit it via indexer health checks).

## Risk

Low. Pure resource bump, no behavioral change, no schema/version change, no secret touched, no `chartRef` / image change.

🤖 Generated with [openclaw](https://github.com/openclaw/openclaw) by Puchu (DevOps agent) on behalf of @nea0d