### PR TITLE
fix(litellm): add missing rules block to route (fixes 404 on litellm.oxygn.dev)

### DIFF
--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -71,6 +71,10 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
     persistence:
       config:
         type: configMap


### PR DESCRIPTION
## Summary

Ajoute le bloc `rules` manquant dans le `route.app` du `HelmRelease` de litellm. Sans ce bloc, le chart `app-template` rend un HTTPRoute **sans backend** → le gateway envoy renvoie 404 pour `https://litellm.oxygn.dev`.

## Cause

```yaml
# kubernetes/apps/ai/litellm/app/helmrelease.yaml (avant)
route:
  app:
    hostnames: ["{{ .Release.Name }}.oxygn.dev"]
    parentRefs: [{name: envoy-internal, namespace: network}]
    # ← pas de rules → HTTPRoute rendu sans backend
```

## Fix

Ajout du bloc `rules` avec le `backendRefs` qui pointe sur le port du service (anchor `*port` déjà défini) :

```yaml
route:
  app:
    hostnames: ["{{ .Release.Name }}.oxygn.dev"]
    parentRefs: [{name: envoy-internal, namespace: network}]
    rules:                                    # ← ajouté
      - backendRefs:
          - identifier: app
            port: *port                        # → 4000, port du service.app.ports.http
```

## Vérification

Test en direct avant fix :
```
https://search.oxygn.dev/   -> 200 ✓
https://devclaw.oxygn.dev/  -> 200 ✓
https://hubble.oxygn.dev/   -> 200 ✓
https://litellm.oxygn.dev/  -> 404 ✗  (HTTPRoute sans backend)
```

Même pattern de `rules` que searxng, devclaw, hubble (qui marchent tous).

## Test post-merge

Une fois mergé, attendre la reconciliation Flux (~1 min), puis :
```bash
curl -sk -o /dev/null -w "%{http_code}\n" https://litellm.oxygn.dev/
# attendu: 200
```

## Notes annexes (à traiter séparément)

- ⚠️ DB non connectée : le login `/v2/login` retourne 400 `Not connected to DB!` car la configmap n'a pas de `database_url`. À voir si tu veux que je rajoute une DB Postgres ou qu'on configure le mode in-memory.
- 🔁 Crashloop intermittent : l'app a crashloop quelques heures (exit 137 + liveness agressive), maintenant stable sur 964Mi/2Gi. Si ça recommence, on bumpera le memory limit à 4Gi.

🤖 Ouvert par l'agent devops (Puchu) via MCP GitHub.