### PR TITLE
fix(rook-ceph): disable memory-leaking mgr modules + bump limit to 2Gi

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
           - name: insights
             enabled: false
           - name: pg_autoscaler
-            enabled: true
+            enabled: false
           - name: rook
             enabled: true
           - name: restful

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -53,11 +53,15 @@ spec:
           - name: diskprediction_local
             enabled: true
           - name: insights
-            enabled: true
+            enabled: false
           - name: pg_autoscaler
             enabled: true
           - name: rook
             enabled: true
+          - name: restful
+            enabled: false
+          - name: telemetry
+            enabled: false
       network:
         provider: host
         addressRanges:
@@ -73,7 +77,7 @@ spec:
             cpu: 100m
             memory: 512Mi
           limits:
-            memory: 1Gi
+            memory: 2Gi
         mon:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Contexte

`rook-ceph-mgr-a` a OOMKilled récemment après être monté progressivement à 1Gi (la limit) sur ~1 semaine. C'est un leak mémoire chronique connu de Ceph mgr — pas spécifique à ce cluster, et plusieurs issues/PRs upstream le documentent depuis 2020.

## État actuel

```
NAME                               CPU    MEMORY
rook-ceph-mgr-a-7d9d5d6c47-dx5zg   137m   619Mi   (est monté jusqu'à 1Gi avant OOM)
rook-ceph-mgr-b-7bf558b48d-6lvbx   68m    499Mi
limit: 1Gi
Rook v1.20.0
```

Modules Ceph explicitement activés (extrait de `cluster/helmrelease.yaml`) :
- `diskprediction_local: true`
- `insights: true`
- `pg_autoscaler: true`
- `rook: true`

Plus les modules default : `dashboard`, `prometheus`, `balancer`, `crash`, `orchestrator`, `status`, `volumes`, `restful`, `telemetry`, `devicehealth`, `pg_autoscaler`.

## Changements

### 1. Désactiver les modules qui lèent ou ne servent à rien en self-hosted

| Module | Avant | Après | Pourquoi |
|---|---|---|---|
| `restful` | (default ON) | `enabled: false` | **Known leaker** — `mgr_restful` a un bug mémoire documenté dans Ceph 17.2.x (mailing list Ceph Users, r/ceph). Sert du REST API style Zabbix, pas utilisé ici (Prometheus scrape direct port 9283). |
| `telemetry` | (default ON) | `enabled: false` | Envoie les stats cluster à `ceph.com` via le module Telemetry. Inutile en self-hosted, on coupe le téléphone. |
| `insights` | `enabled: true` | `enabled: false` | Envoie le `health_history` à `ceph.com`. Bouffe de la mémoire avec sa retention, sans valeur opérationnelle. `diskprediction_local` reste actif pour la prédiction locale des pannes disques. |
| `pg_autoscaler` | `enabled: true` | `enabled: false` | Calcule toutes les 5s, ajuste les PG par pool dynamiquement. Pour un cluster stable à 4 pools (81 PGs total) sans croissance prévue, c'est de l'overhead inutile. Économise CPU et un peu de mémoire. |

### 2. Bump memory limit 1Gi → 2Gi

| | Avant | Après |
|---|---|---|
| `resources.mgr.limits.memory` | `1Gi` | `2Gi` |

Recommandation de la communauté (r/ceph, oneuptime) pour clusters small/medium comme le nôtre (81 PGs, 928 GiB total). Donne de la marge avant le prochain OOM, le temps que le leak se manifeste.

### Module explicitement GARDÉ : `diskprediction_local`

Le `cephConfig.global.device_failure_prediction_mode: local` a le commentaire `# requires mgr module`. Désactiver `diskprediction_local` casserait cette config. C'est le seul filet de prédiction de panne disque local sur nos 3 OSDs.

## Vérification après merge

Une fois mergé (~1 min reconciliation Flux) :

```bash
# 1. Confirmer modules disabled
kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph mgr module ls | grep -E "restful|telemetry|insights|pg_autoscaler"
# attendu: tous disabled (tiret ou absent dans la colonne)

# 2. Surveiller la mémoire sur 24h
kubectl top pods -n rook-ceph -l app=rook-ceph-mgr
# mgr-a et mgr-b doivent rester stables, pas croissance continue
```

## Refs

- rook/rook#6000 (2020) — "rook-ceph-mgr-a CrashLoopBackOff, possible memory leak", même pattern
- rook/rook#15499 (2025) — "Operator memory leak", 3000+ namespaces
- spinics.net/lists/ceph-users — "MGR Memory Leak in Restful" (Ceph 17.2.5/17.2.6)
- r/ceph — "Limiting mgr memory usage" (up to 150GB leak reporté)
- https://oneuptime.com/blog — "How to Set Memory Requests and Limits for Rook-Ceph"

## Hors scope (à voir plus tard)

- `prometheus` module (default) est aussi connu pour accumuler de l'état. Si le leak continue après ces fixes, le désactiver est une option (mais cassera les métriques Ceph custom sur port 9283).
- Ceph Quincy → Reef/Squid upgrade pourrait apporter des fixes upstream (v1.20.0 rook utilise une version récente mais le bug restful peut être upstream).
- Alerting Prometheus à mettre en place sur `container_memory_working_set_bytes{pod=~"rook-ceph-mgr.*"}` qui trend > 80% sur 24h.

🤖 Ouvert par l'agent devops (Puchu) via MCP GitHub.