### PR TITLE
feat(ai): add Headroom deployment and integrate with devclaw

### DIFF
--- a/kubernetes/apps/ai/devclaw/app/resources/openclaw.json
+++ b/kubernetes/apps/ai/devclaw/app/resources/openclaw.json
@@ -251,7 +251,7 @@
   "models": {
     "providers": {
       "litellm": {
-        "baseUrl": "http://litellm.ai:4000/v1",
+        "baseUrl": "http://headroom.ai:8787/v1",
         "apiKey": { "source": "env", "provider": "default", "id": "LITELLM_API_KEY" },
         "api": "openai-completions",
         "timeoutSeconds": 600,
@@ -266,7 +266,7 @@
         ]
       },
       "litellm-anthropic": {
-        "baseUrl": "http://litellm.ai:4000",
+        "baseUrl": "http://headroom.ai:8787",
         "apiKey": { "source": "env", "provider": "default", "id": "LITELLM_API_KEY" },
         "api": "anthropic-messages",
         "timeoutSeconds": 600,

--- a/kubernetes/apps/ai/headroom/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/headroom/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headroom
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: headroom
+  interval: 30m
+  values:
+    controllers:
+      headroom:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/chopratejas/headroom
+              tag: latest
+            args: ["proxy", "--host", "0.0.0.0", "--port", "8787"]
+            env:
+              TZ: Europe/Paris
+              OPENAI_TARGET_API_URL: http://litellm.ai:4000/v1
+              ANTHROPIC_TARGET_URL: http://litellm.ai:4000
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8787
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8787
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8787
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: 8787
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.oxygn.dev"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8787                  # → Headroom proxy port

--- a/kubernetes/apps/ai/headroom/app/kustomization.yaml
+++ b/kubernetes/apps/ai/headroom/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/headroom/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/headroom/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: headroom
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/headroom/ks.yaml
+++ b/kubernetes/apps/ai/headroom/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: headroom
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: headroom
+  interval: 1h
+  path: "./kubernetes/apps/ai/headroom/app"
+  postBuild:
+    substitute:
+      APP: headroom
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./devclaw/ks.yaml
+  - ./headroom/ks.yaml
   - ./litellm/ks.yaml
   - ./searxng/ks.yaml
   - ./toolhive/ks.yaml


### PR DESCRIPTION
- Add Headroom proxy deployment (ghcr.io/chopratejas/headroom)
- Configure Headroom to forward requests to Litellm- Update devclaw config to use Headroom as LLM provider
- Expose Headroom via Envoy (headroom.oxygn.dev)