### PR TITLE
fix(toolhive): align todoist-mcp binary port with operator target_port

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/todoist-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/todoist-mcp/mcpserver.yaml
@@ -15,7 +15,7 @@ spec:
     - name: NPM_CONFIG_CACHE
       value: /tmp/.npm
     - name: PORT
-      value: "3000"
+      value: "8080"
   secrets:
     - name: toolhive-todoist
       key: TODOIST_API_KEY


### PR DESCRIPTION
## Summary

Fix the **todoist-mcp proxy → backend connection refused** issue that PR #3195 left behind. The deployment is up (pods Running, `todoist-mcp-http` binary is serving on port 3000), but the toolhive operator's proxy is dialing the pod on **port 8080** and getting `connect: connection refused`.

## Root cause

The `toolhive` operator v0.29.3 ignores `spec.targetPort` and always sets `runconfig.target_port = spec.port` (default 8080). The operator's proxy uses this port to forward requests to the backend pod.

The `@doist/todoist-mcp-http` binary reads **only** `process.env.PORT` (default `3000`, per the source code at `src/main-http.ts`). It does **not** read `MCP_PORT` or `FASTMCP_PORT` (those are FastMCP conventions, not used by this binary).

So:
- `runconfig.target_port` = `8080` (operator default)
- `process.env.PORT` in the pod = `3000` (binary default)
- Operator proxy → `pod:8080` → connection refused
- Pod binary is actually listening on `3000`

## Evidence

From the `todoist-mcp-6566946488-z94sb` (proxy) logs:
```
ERROR  failed to forward request
  error="dial tcp 10.43.237.133:8080: connect: connection refused"
```

From the `todoist-mcp-0` (backend) logs — the binary **is** healthy and serving on 3000:
```
Todoist MCP HTTP Server started on port 3000
MCP endpoint: http://localhost:3000/mcp
Health check: http://localhost:3000/health
```

## Fix

One-line change: set `PORT=8080` in the `MCPServer` env so the binary listens on the port the operator's proxy actually forwards to. This is consistent with the convention used by the other streamable-http MCPs in the cluster (flux, kubectl, talos all set `MCP_PORT` / `FASTMCP_PORT` to match `target_port` — todoist just needs `PORT` because it's not a FastMCP server).

## Changes

- **modified** `kubernetes/apps/ai/toolhive/mcp-servers/todoist-mcp/mcpserver.yaml` — `PORT: "3000"` → `PORT: "8080"`

## Validation

`mise exec -- flate test ks --path ./kubernetes/apps/ai/toolhive` → **9 passed, 0 failed, 3 blocked** (the blocked ones are unrelated dependency blocks).

## Verification after merge

1. Flux reconciles `Kustomization/todoist-mcp` within 1–2 min
2. Toolhive operator updates the StatefulSet, `todoist-mcp-0` restarts with new env
3. New pod logs should show:
   ```
   Todoist MCP HTTP Server started on port 8080
   ```
4. Proxy logs (`todoist-mcp-*-xxxxx`) should stop showing `connection refused`
5. End-to-end test: hit `mcp-todoist-mcp-proxy.ai:8080/mcp` or via the gateway

## Follow-up (optional)

If the upstream toolhive operator gains proper `targetPort` support, this fix could be reverted in favor of `targetPort: 3000` + `PORT: 3000`. Filed as: `TODO(operator): wait for targetPort field to be honored in toolhive MCPServer v1alpha1`.

Closes: #3195 (the original fix that exposed this issue)