### PR TITLE
fix(toolhive): exclude broken todoist-mcp_get-overview tool via filter allow-list

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
@@ -13,17 +13,61 @@ spec:
         prefixFormat: "{workload}_"
       tools:
         - workload: todoist-mcp
-          exclude:
-            - "get-overview"
-  # embeddingServerRef:
-  #   name: mcp-tools-embedding
+          filter:
+            - add-comments
+            - add-filters
+            - add-goals
+            - add-labels
+            - add-projects
+            - add-reminders
+            - add-sections
+            - add-tasks
+            - analyze-project-health
+            - complete-goals
+            - complete-tasks
+            - delete-object
+            - fetch
+            - fetch-object
+            - find-activity
+            - find-comments
+            - find-completed-tasks
+            - find-filters
+            - find-goals
+            - find-labels
+            - find-project-collaborators
+            - find-projects
+            - find-reminders
+            - find-sections
+            - find-tasks
+            - find-tasks-by-date
+            - get-productivity-stats
+            - get-project-activity-stats
+            - get-project-health
+            - get-workspace-insights
+            - link-goal-tasks
+            - list-workspaces
+            - manage-assignments
+            - project-management
+            - project-move
+            - reorder-objects
+            - reschedule-tasks
+            - search
+            - uncomplete-tasks
+            - update-comments
+            - update-filters
+            - update-goals
+            - update-labels
+            - update-projects
+            - update-reminders
+            - update-sections
+            - update-tasks
+            - user-info
+            - view-attachment
+  embeddingServerRef:
+    name: mcp-tools-embedding
   telemetryConfigRef:
     name: prometheus
   incomingAuth:
     type: anonymous
   outgoingAuth:
     source: discovered
-  # sessionStorage:
-  #   address: toolhive-dragonfly.ai.svc.cluster.local:6379
-  #   keyPrefix: "mcp-gateway-internal:"
-  #   provider: redis


### PR DESCRIPTION
## Contexte

Le tool `todoist-mcp_get-overview` expose un JSON Schema cassé (référence `#/definitions/__schema0` introuvable). Ce schema invalide fait échouer le probe MCP d'OpenClaw.

```
[bundle-mcp] failed to start server toolhive: Error: can't resolve reference #/definitions/__schema0 from id #
```

## Problème avec l'approche précédente (commit 5a77ffc65)

Le CRD `VirtualMCPServer` n'a PAS de champ `exclude` au niveau du tool filter. Les seuls champs valides sont:
- `excludeAll` (booléen) — exclut TOUS les tools d'un workload
- `filter` (array) — allow-list des tools à exposer

Le champ `exclude` est silencieusement pruné par l'API server Kubernetes (unknown field pruning par défaut pour les CRD). La config précédente avec `exclude` était donc **inactive**.

## Fix

Utilise `filter` (allow-list) avec les 49 tools valides du workload `todoist-mcp`, en omettant `get-overview`.

## Changement

| Avant (inactif) | Après (effectif) |
|---|---|
| `exclude: ["get-overview"]` | `filter: [add-comments, add-filters, ..., view-attachment]` |

49 tools listés explicitement (tous sauf `get-overview`).

Nettoie aussi le commentaire accidentel sur `embeddingServerRef` et les lignes `sessionStorage` qui ne font pas partie du CRD.