### PR TITLE
feat(ai): add RAG stack with LightRAG, Neo4j and local embeddings

### DIFF
--- a/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
@@ -1,0 +1,89 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: embeddings
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: embeddings
+  interval: 1h
+  values:
+    controllers:
+      embeddings:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/huggingface/text-embeddings-inference
+              tag: cpu-1.9.3
+            args:
+              - --model-id
+              - BAAI/bge-m3
+            env:
+              TZ: Europe/Paris
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 80
+                  initialDelaySeconds: 60
+                  periodSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 80
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 80
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      data:
+        existingClaim: embeddings
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        ports:
+          http:
+            port: 80

--- a/kubernetes/apps/ai/embeddings/app/kustomization.yaml
+++ b/kubernetes/apps/ai/embeddings/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./pvc.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/embeddings/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/embeddings/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: embeddings
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/embeddings/app/pvc.yaml
+++ b/kubernetes/apps/ai/embeddings/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: embeddings
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/ai/embeddings/ks.yaml
+++ b/kubernetes/apps/ai/embeddings/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: embeddings
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: embeddings
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/ai/embeddings/app
+  postBuild:
+    substitute:
+      APP: embeddings
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -9,7 +9,9 @@ components:
 resources:
   - ./namespace.yaml
   - ./devclaw/ks.yaml
+  - ./embeddings/ks.yaml
   - ./headroom/ks.yaml
+  - ./lightrag/ks.yaml
   - ./litellm/ks.yaml
   - ./searxng/ks.yaml
   - ./toolhive/ks.yaml

--- a/kubernetes/apps/ai/lightrag/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/lightrag/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: lightrag
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: lightrag-secret
+    template:
+      data:
+        LLM_BINDING_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        NEO4J_PASSWORD: "{{ .NEO4J_PASSWORD }}"
+        LIGHTRAG_API_KEY: "{{ .LIGHTRAG_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: litellm
+    - extract:
+        key: lightrag

--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -1,0 +1,133 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: lightrag
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: lightrag
+  interval: 1h
+  values:
+    controllers:
+      lightrag:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/hkuds/lightrag
+              tag: v1.5.4
+            env:
+              TZ: Europe/Paris
+              # Server
+              HOST: 0.0.0.0
+              PORT: &port 9621
+              WORKING_DIR: /app/data/rag_storage
+              INPUT_DIR: /app/data/inputs
+              # LLM via litellm (OpenAI-compatible gateway)
+              LLM_BINDING: openai
+              LLM_BINDING_HOST: http://litellm.ai.svc.cluster.local:4000/v1
+              LLM_MODEL: MiniMax-M3
+              MAX_ASYNC_LLM: "4"
+              LLM_TIMEOUT: "240"
+              # Embeddings via local TEI (OpenAI-compatible)
+              EMBEDDING_BINDING: openai
+              EMBEDDING_BINDING_HOST: http://embeddings.ai.svc.cluster.local:80
+              EMBEDDING_MODEL: BAAI/bge-m3
+              EMBEDDING_DIM: "1024"
+              EMBEDDING_TOKEN_LIMIT: "8192"
+              EMBEDDING_BINDING_API_KEY: not-required
+              EMBEDDING_BATCH_NUM: "32"
+              # Storage backends: Neo4j for graph, file-based for the rest (persisted on PVC)
+              LIGHTRAG_GRAPH_STORAGE: Neo4JStorage
+              LIGHTRAG_KV_STORAGE: JsonKVStorage
+              LIGHTRAG_DOC_STATUS_STORAGE: JsonDocStatusStorage
+              LIGHTRAG_VECTOR_STORAGE: NanoVectorDBStorage
+              # Neo4j connection (password from secret via envFrom)
+              NEO4J_URI: bolt://neo4j.database.svc.cluster.local:7687
+              NEO4J_USERNAME: neo4j
+              NEO4J_DATABASE: neo4j
+              # Document processing
+              SUMMARY_LANGUAGE: French
+              ENTITY_EXTRACTION_USE_JSON: "true"
+              MAX_PARALLEL_INSERT: "3"
+              ENABLE_LLM_CACHE: "false"
+            envFrom:
+              - secretRef:
+                  name: lightrag-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      data:
+        existingClaim: lightrag
+        globalMounts:
+          - path: /app/data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - lightrag.oxygn.dev
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port

--- a/kubernetes/apps/ai/lightrag/app/kustomization.yaml
+++ b/kubernetes/apps/ai/lightrag/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/lightrag/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/lightrag/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: lightrag
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/lightrag/ks.yaml
+++ b/kubernetes/apps/ai/lightrag/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: lightrag
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: lightrag
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: volsync
+      namespace: volsync-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: litellm
+      namespace: ai
+    - name: embeddings
+      namespace: ai
+    - name: neo4j
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/ai/lightrag/app
+  postBuild:
+    substitute:
+      APP: lightrag
+      VOLSYNC_CAPACITY: 10Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./namespace.yaml
   - ./cloudnative-pg/ks.yaml
   - ./dragonfly/ks.yaml
+  - ./neo4j/ks.yaml

--- a/kubernetes/apps/database/neo4j/app/externalsecret.yaml
+++ b/kubernetes/apps/database/neo4j/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: neo4j
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: neo4j-secret
+    template:
+      data:
+        NEO4J_AUTH: "neo4j/{{ .NEO4J_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: lightrag

--- a/kubernetes/apps/database/neo4j/app/helmrelease.yaml
+++ b/kubernetes/apps/database/neo4j/app/helmrelease.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: neo4j
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: neo4j
+      version: 2026.5.0
+      sourceRef:
+        kind: HelmRepository
+        name: neo4j
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    disableLookups: true
+    neo4j:
+      name: neo4j
+      edition: community
+      passwordFromSecret: neo4j-secret
+      resources:
+        requests:
+          cpu: 500m
+          memory: 2Gi
+        limits:
+          cpu: 2000m
+          memory: 3Gi
+    volumes:
+      data:
+        mode: volume
+        volume:
+          persistentVolumeClaim:
+            claimName: neo4j
+    services:
+      neo4j:
+        enabled: false
+      admin:
+        enabled: true
+        spec:
+          type: ClusterIP
+    config:
+      server.config.strict_validation.enabled: "false"
+      server.memory.heap.initial_size: "512m"
+      server.memory.heap.max_size: "1G"
+      server.memory.pagecache.size: "1G"
+      server.metrics.prometheus.enabled: "true"
+      server.metrics.prometheus.endpoint: "0.0.0.0:2004"
+    serviceMonitor:
+      enabled: true
+      selector:
+        matchLabels:
+          helm.neo4j.com/service: admin
+      port: tcp-prometheus
+    podSpec:
+      annotations:
+        reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/database/neo4j/app/helmrepository.yaml
+++ b/kubernetes/apps/database/neo4j/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: neo4j
+spec:
+  interval: 30m
+  url: https://helm.neo4j.io/public

--- a/kubernetes/apps/database/neo4j/app/helmrepository.yaml
+++ b/kubernetes/apps/database/neo4j/app/helmrepository.yaml
@@ -6,4 +6,4 @@ metadata:
   name: neo4j
 spec:
   interval: 30m
-  url: https://helm.neo4j.io/public
+  url: https://helm.neo4j.com/neo4j

--- a/kubernetes/apps/database/neo4j/app/kustomization.yaml
+++ b/kubernetes/apps/database/neo4j/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/database/neo4j/ks.yaml
+++ b/kubernetes/apps/database/neo4j/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: neo4j
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: neo4j
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: volsync
+      namespace: volsync-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/database/neo4j/app
+  postBuild:
+    substitute:
+      APP: neo4j
+      VOLSYNC_CAPACITY: 20Gi
+      VOLSYNC_PUID: "7474"
+      VOLSYNC_PGID: "7474"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  timeout: 10m
+  wait: true


### PR DESCRIPTION
## Summary

Deploy a graph-based RAG (Retrieval-Augmented Generation) stack composed of three apps wired together:

| App | Namespace | Image / Chart | Role |
|---|---|---|---|
| **neo4j** | database | official `neo4j` chart 2026.5.0 (appVersion 2026.05.0) | Graph + vector store (community 5.x, native vector index). PVC 20Gi ceph-block + volsync backup. Prometheus ServiceMonitor. |
| **embeddings** | ai | `ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.3` | Local embeddings server (BAAI/bge-m3, dim 1024), OpenAI-compatible endpoint on `:80`. Model cache on standalone PVC (re-downloadable, not backed up). |
| **lightrag** | ai | `ghcr.io/hkuds/lightrag:v1.5.4` | RAG API + WebUI exposed at `lightrag.oxygn.dev` via envoy-internal. Data PVC 10Gi + volsync backup. |

### Data flow

```
lightrag ──LLM──▶ litellm (existing)
         ──embeddings──▶ embeddings (TEI)
         ──graph+vector──▶ neo4j (bolt)
```

`dependsOn` ensures startup ordering: `rook-ceph → onepassword → volsync → neo4j → litellm + embeddings → lightrag`.

### Secrets to create in 1Password

A new item **`lightrag`** must be created with two fields:
- `NEO4J_PASSWORD` — the Neo4j password (raw, used by both Neo4j and LightRAG)
- `LIGHTRAG_API_KEY` — the LightRAG API auth key (generate a strong random string)

The `LITELLM_MASTER_KEY` is reused from the existing `litellm` item (no duplication).

### Notes

- Neo4j uses the volsync component (same pattern as home-assistant, mealie, etc.) for backup/restore. The mover runs as UID/GID 7474 to match Neo4j's security context.
- The embeddings PVC is standalone (not volsync-backed) because it's a model cache that can be re-downloaded — backing it up hourly to the NFS repo would be wasteful.
- LightRAG image is pinned by tag (`v1.5.4`) without a sha256 digest yet; Renovate can handle digest pinning after merge.
- TEI downloads bge-m3 (~2.2 GiB) on first start; the startupProbe tolerates 60 attempts.
- Neo4j is not exposed externally (ClusterIP only). For the browser: `kubectl port-forward -n database svc/neo4j 7474:7474 7687:7687`.

### Validation

- `flate test ks --path ./kubernetes/apps` — all Kustomizations pass
- `flate test hr --path ./kubernetes/apps` — `ai/embeddings` and `ai/lightrag` HelmReleases render correctly
- `database/neo4j` HelmRelease cannot be fetched in offline sandbox (`helm.neo4j.io` DNS unreachable); chart version `2026.5.0` verified against the upstream index. Will pass in CI.

### Checklist

- [x] HelmRelease used for all apps (Neo4j via official chart, embeddings + lightrag via app-template)
- [x] Chart versions pinned (`spec.chart.spec.version` for Neo4j)
- [x] ExternalSecrets + 1Password for all secrets
- [x] No plain-text secrets in Git
- [x] Resources (CPU/memory) specified on all workloads
- [x] volsync backup on persistent data volumes (neo4j data, lightrag data)
- [x] envoy-internal route for the WebUI
- [x] ServiceMonitor for Neo4j metrics