### PR TITLE
fix(embeddings): bump memory limit to 6Gi to avoid OOMKilled at warmup

### DIFF
--- a/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
@@ -59,9 +59,9 @@ spec:
             resources:
               requests:
                 cpu: 500m
-                memory: 2Gi
+                memory: 3Gi
               limits:
-                memory: 4Gi
+                memory: 6Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
bge-m3 (XLM-RoBERTa-large, 560M) on the TEI CPU ONNX backend peaks ~5-7Gi during model warmup (ONNX arena allocator + 8192-token attention buffers), exceeding the previous 4Gi limit. The pod OOMKills in ~8s before metrics can sample the transient spike, which is why steady-state RSS looked fine.

Raise requests to 3Gi and limits to 6Gi. No model change, no re-embedding needed.