### PR TITLE
fix(neo4j): set ServiceMonitor interval and path to avoid null fields

### DIFF
--- a/kubernetes/apps/database/neo4j/app/helmrelease.yaml
+++ b/kubernetes/apps/database/neo4j/app/helmrelease.yaml
@@ -59,6 +59,8 @@ spec:
         matchLabels:
           helm.neo4j.com/service: admin
       port: tcp-prometheus
+      interval: 30s
+      path: /metrics
     podSpec:
       annotations:
         reloader.stakater.com/auto: "true"


### PR DESCRIPTION
The neo4j chart 2026.5.0 templates ServiceMonitor endpoints without quoting or defaulting interval/path (neo4j-servicemonitor.yaml:13-14):

  interval: {{ .Values.serviceMonitor.interval }}
  path: {{ .Values.serviceMonitor.path }}

When these are left empty (the chart default ""), the rendered YAML becomes 'interval:' with no value, i.e. null, which the ServiceMonitor CRD rejects (these fields must be strings). This has broken every Helm upgrade since the RAG stack was introduced (commit f829e61c0), leaving neo4j in a Failed state and blocking lightrag.

Set interval=30s and path=/metrics explicitly so the template emits valid strings.