### PR TITLE
fix(ai): switch embeddings to gte-multilingual-base, fix lightrag dim

### DIFF
--- a/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
               tag: cpu-1.9.3
             args:
               - --model-id
-              - BAAI/bge-m3
+              - Alibaba-NLP/gte-multilingual-base
             env:
               TZ: Europe/Paris
             probes:
@@ -60,6 +60,8 @@ spec:
               requests:
                 cpu: 500m
                 memory: 2Gi
+              limits:
+                memory: 5Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -36,8 +36,8 @@ spec:
               # Embeddings via local TEI (OpenAI-compatible)
               EMBEDDING_BINDING: openai
               EMBEDDING_BINDING_HOST: http://embeddings.ai.svc.cluster.local:80
-              EMBEDDING_MODEL: BAAI/bge-m3
-              EMBEDDING_DIM: "1024"
+              EMBEDDING_MODEL: Alibaba-NLP/gte-multilingual-base
+              EMBEDDING_DIM: "768"
               EMBEDDING_TOKEN_LIMIT: "8192"
               EMBEDDING_BINDING_API_KEY: not-required
               EMBEDDING_BATCH_NUM: "32"


### PR DESCRIPTION
bge-m3 (560M, XLM-RoBERTa-large) peaks at ~11GB RAM on the cluster's Xeon E5-2650 v2 CPUs (Ivy Bridge, no AVX2/FMA). The ONNX Runtime CPU backend on non-AVX2 hardware allocates oversized generic kernels and buffers, making the model unhostable on this hardware (a 13Gi memory limit would be required; the nodes only have ~30Gi and are already at ~67% requests).

Switch to Alibaba-NLP/gte-multilingual-base (305M, dim 768, ctx 8192):
- 70+ languages incl. French (SUMMARY_LANGUAGE=French)
- Same 8192 token context (no re-chunking)
- ~5x smaller; expected peak ~3-4Gi on non-AVX2 hardware
- Set limits.memory=5Gi for headroom

Update lightrag envs to match:
- EMBEDDING_MODEL: Alibaba-NLP/gte-multilingual-base
- EMBEDDING_DIM: 1024 -> 768

No re-embedding needed: lightrag never ran (neo4j was down since the RAG stack was introduced in f829e61c0), so the corpus storage is empty.

Embeddings alternatives considered and rejected:
- all-MiniLM-L6-v2: english-only, ctx 256, unsuitable for FR RAG
- Mistral-embed via litellm: not self-hostable, API cost/latency
- bge-m3 with --dtype float16: fp16 without FMA/AVX2 is emulated, slower and more memory-hungry
- opencode-go / MiniMax embo-01: no /v1/embeddings endpoint (opencode-go) or proprietary format + strict RPM limit (MiniMax), neither litellm- compatible for embeddings