### PR TITLE
fix(lightrag): replace volsync restore with fresh PVC

### DIFF
--- a/kubernetes/apps/ai/lightrag/app/kustomization.yaml
+++ b/kubernetes/apps/ai/lightrag/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./pvc.yaml
   - ./ocirepository.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/ai/lightrag/app/pvc.yaml
+++ b/kubernetes/apps/ai/lightrag/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lightrag
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/ai/lightrag/ks.yaml
+++ b/kubernetes/apps/ai/lightrag/ks.yaml
@@ -8,13 +8,9 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: lightrag
-  components:
-    - ../../../../components/volsync
   dependsOn:
     - name: onepassword
       namespace: external-secrets
-    - name: volsync
-      namespace: volsync-system
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: litellm
@@ -28,7 +24,6 @@ spec:
   postBuild:
     substitute:
       APP: lightrag
-      VOLSYNC_CAPACITY: 10Gi
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Problem

The volsync `ReplicationDestination` restored **Tautulli** data from the shared Kopia repository onto the LightRAG PVC. The `sourceIdentity` filtering did not prevent the cross-source restore, resulting in `EBADMSG` (errno 74) filesystem corruption on the PVC.

The LightRAG pod crashed with:
```
OSError: [Errno 74] Bad message: '/app/data/inputs'
```

## Root Cause

All apps share the same Kopia repository (`volsync-template` 1Password item). The `ReplicationDestination` for lightrag had `trigger: manual: restore-once`, which fired on first deployment. Since no `lightrag@ai` snapshots existed yet, it restored the latest snapshot in the repository — which was `tautulli@media`.

## Fix

1. **Remove volsync component** from `ks.yaml` temporarily — prevents the broken restore from recontaminating the PVC
2. **Add standalone PVC** (`pvc.yaml`) without `dataSourceRef` — provisions a fresh Ceph RBD volume
3. **Cluster cleanup** (already done): deleted corrupted PVC, VolumeSnapshot, ReplicationDestination, ReplicationSource, and stale volsync secrets

## Next Steps (after merge)

- Resume the Flux Kustomization (currently suspended)
- Verify LightRAG starts successfully
- Re-add volsync component once the app has stable data and a valid first backup exists