### PR TITLE
fix(ai): harden embeddings liveness probe and reduce lightrag embedding pressure

### DIFF
--- a/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
@@ -23,6 +23,10 @@ spec:
             args:
               - --model-id
               - intfloat/multilingual-e5-base
+              - --max-concurrent-requests
+              - "16"
+              - --max-batch-tokens
+              - "8192"
             env:
               TZ: Europe/Paris
             probes:
@@ -35,7 +39,8 @@ spec:
                     port: 80
                   initialDelaySeconds: 60
                   periodSeconds: 10
-                  failureThreshold: 3
+                  timeoutSeconds: 15
+                  failureThreshold: 5
               readiness:
                 enabled: true
                 custom: true
@@ -45,7 +50,8 @@ spec:
                     port: 80
                   initialDelaySeconds: 10
                   periodSeconds: 10
-                  failureThreshold: 3
+                  timeoutSeconds: 15
+                  failureThreshold: 5
               startup:
                 enabled: true
                 custom: true
@@ -58,7 +64,7 @@ spec:
                   failureThreshold: 30
             resources:
               requests:
-                cpu: 500m
+                cpu: 2000m
                 memory: 2Gi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -40,7 +40,9 @@ spec:
               EMBEDDING_DIM: "768"
               EMBEDDING_TOKEN_LIMIT: "512"
               EMBEDDING_BINDING_API_KEY: not-required
-              EMBEDDING_BATCH_NUM: "32"
+              EMBEDDING_BATCH_NUM: "16"
+              EMBEDDING_FUNC_MAX_ASYNC: "4"
+              EMBEDDING_TIMEOUT: "60"
               # Storage backends: Neo4j for graph, file-based for the rest (persisted on PVC)
               LIGHTRAG_GRAPH_STORAGE: Neo4JStorage
               LIGHTRAG_KV_STORAGE: JsonKVStorage
@@ -57,7 +59,7 @@ spec:
               CHUNK_SIZE: "500"
               CHUNK_OVERLAP_SIZE: "100"
               ENTITY_EXTRACTION_USE_JSON: "true"
-              MAX_PARALLEL_INSERT: "3"
+              MAX_PARALLEL_INSERT: "1"
               ENABLE_LLM_CACHE: "false"
             envFrom:
               - secretRef:


### PR DESCRIPTION
## Problem

The pod `embeddings-5d67ff4548-62br9` kept restarting during lightrag indexing, aborting document ingestion with:

```
NanoVectorDBStorage[entities] index flush failed: Embedding func: Worker execution timeout after 60s
```

## Root cause

The embeddings pod (`text-embeddings-inference` CPU build, `multilingual-e5-base`) was **killed by kubelet**, not OOM-killed:

```
Liveness probe failed: Get "http://10.42.2.39:80/health": context deadline exceeded
Container app failed liveness probe, will be restarted   (exit 137, reason: Error)
```

The liveness/readiness probes did not set `timeoutSeconds`, so k8s applied the **1s default**. A CPU-bound inference server legitimately exceeds 1s under batch load; 3 consecutive 1s timeouts killed the container, dropping in-flight embedding requests. lightrag then hit its embedding worker `max_execution_timeout` = `EMBEDDING_TIMEOUT * 2` = 30 * 2 = **60s** (defaults, since neither env var was set) and aborted the index flush.

The 60s lightrag timeout is a **symptom** of the TEI kill, not the root cause.

## Changes

### `ai/embeddings` (root-cause fix)
- liveness & readiness: `timeoutSeconds: 15`, `failureThreshold: 5` (was default 1s / 3)
- cpu request `500m` -> `2000m` (no limit kept, to preserve bursting)
- TEI args: `--max-concurrent-requests 16`, `--max-batch-tokens 8192` — forces 429 backpressure instead of saturating and starving `/health`

### `ai/lightrag` (reduce peak load + retry headroom)
- `EMBEDDING_BATCH_NUM` 32 -> 16
- `EMBEDDING_FUNC_MAX_ASYNC` 8 (default) -> 4
- `EMBEDDING_TIMEOUT` 30 (default) -> 60 (worker timeout = 120s, lets retries succeed)
- `MAX_PARALLEL_INSERT` 3 -> 1

## Validation
- `flate test hr --path ./kubernetes/apps`: **81 passed**, 3 pre-existing warnings unrelated to this change.