### PR TITLE
fix(ai): revert TEI concurrency limits, rely on liveness probe fix

### DIFF
--- a/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/embeddings/app/helmrelease.yaml
@@ -23,10 +23,6 @@ spec:
             args:
               - --model-id
               - intfloat/multilingual-e5-base
-              - --max-concurrent-requests
-              - "16"
-              - --max-batch-tokens
-              - "8192"
             env:
               TZ: Europe/Paris
             probes:
@@ -64,7 +60,7 @@ spec:
                   failureThreshold: 30
             resources:
               requests:
-                cpu: 2000m
+                cpu: 1000m
                 memory: 2Gi
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Context

Follow-up to #3361. The embeddings pod is no longer killed (liveness fix worked), but lightrag now fails indexing with:

```
NanoVectorDBStorage[entities]: RetryError[<Future ... raised RateLimitError>]
openai.RateLimitError: Error code: 429 - {'message': 'Model is overloaded', 'type': 'Overloaded'}
```

## Root cause

The `--max-concurrent-requests 16` / `--max-batch-tokens 8192` args added in #3361 to force TEI backpressure backfired:

1. **`--max-batch-tokens 8192` killed batching throughput.** One lightrag request = 16 texts × 512 tokens = 8192 tokens, which fills the entire batch budget. TEI could therefore never batch multiple requests into a single forward pass -> sequential processing (~1 req / 2s), roughly halving throughput. TEI logs confirm: `inference_time ~700-1100ms`, one `Success` at a time.

2. **`--max-concurrent-requests 16` returned 429** (`try_acquire_permit ... no permits available` in TEI logs) on burst. lightrag wraps `openai_embed` with a **hardcoded 3-attempt tenacity retry** (`/app/lightrag/llm/openai.py:885`, not env-configurable) on `RateLimitError` with 4-60s backoff. The retry storm (OpenAI client retries + tenacity) exhausted before TEI drained its queue -> `RetryError` -> `IndexFlushError`.

## Fix

The actual fix for the original pod-killing was the **liveness probe** (`timeoutSeconds` 1s -> 15s, `failureThreshold` 3 -> 5) and the **cpu request bump** — not the TEI concurrency cap. Revert TEI to defaults:

- Remove `--max-concurrent-requests 16` (default 128) -> no 429 gate, TEI queues internally
- Remove `--max-batch-tokens 8192` (default 16384) -> TEI can batch 2 lightrag requests per forward pass -> ~2x throughput
- cpu request `2000m` -> `1000m` (2x the original 500m, enough for `/health` to stay responsive within the 15s liveness window without over-reserving the node)

The tolerant liveness probe (15s) keeps TEI from being killed under load even when it queues deeply; the lightrag-side tuning from #3361 (`EMBEDDING_BATCH_NUM=16`, `EMBEDDING_FUNC_MAX_ASYNC=4`, `EMBEDDING_TIMEOUT=60`, `MAX_PARALLEL_INSERT=1`) is kept as-is.

## Validation
- `flate test hr --path ./kubernetes/apps`: **81 passed**, `ai/embeddings` included.