### PR TITLE
feat(npm): track npm packages in toolhive MCP servers

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -30,6 +30,8 @@
   color: "027fa0"
 - name: renovate/terraform
   color: "027fa0"
+- name: renovate/npm
+  color: "027fa0"
 # Semantic Types
 - name: type/digest
   color: "ffeC19"

--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -67,5 +67,13 @@
       matchUpdateTypes: ["minor", "patch"],
       ignoreTests: true,
     },
+    {
+      description: "Auto-merge npm minor and patch",
+      matchDatasources: ["npm"],
+      automerge: true,
+      automergeType: "branch",
+      matchUpdateTypes: ["minor", "patch"],
+      ignoreTests: true,
+    },
   ],
 }

--- a/.renovate/changelogs.json5
+++ b/.renovate/changelogs.json5
@@ -16,5 +16,20 @@
       matchPackageNames: ["/spegel/"],
       changelogUrl: "https://github.com/spegel-org/spegel/blob/main/CHANGELOG.md",
     },
+    {
+      description: "Changelog URL for todoist-mcp",
+      matchPackageNames: ["@doist/todoist-mcp"],
+      changelogUrl: "https://github.com/doist/todoist-mcp",
+    },
+    {
+      description: "Changelog URL for mcp-arr-server",
+      matchPackageNames: ["mcp-arr-server"],
+      changelogUrl: "https://github.com/aplaceforallmystuff/mcp-arr",
+    },
+    {
+      description: "Changelog URL for overseerr-mcp",
+      matchPackageNames: ["@jhomen368/overseerr-mcp"],
+      changelogUrl: "https://github.com/jhomen368/overseerr-mcp",
+    },
   ],
 }

--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -29,5 +29,16 @@
       ],
       datasourceTemplate: "docker",
     },
+    {
+      customType: "regex",
+      description: "Process npm packages in npx args",
+      managerFilePatterns: [
+        "/\\.yaml(?:\\.j2)?$/",
+      ],
+      matchStrings: [
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s*-\\s+\"?[\\S]+@(?<currentValue>[0-9][^\"\\s]*)\"?",
+      ],
+      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}npm{{/if}}",
+    },
   ],
 }

--- a/.renovate/labels.json5
+++ b/.renovate/labels.json5
@@ -33,5 +33,9 @@
       matchDatasources: ["github-releases"],
       addLabels: ["renovate/github-release"],
     },
+    {
+      matchDatasources: ["npm"],
+      addLabels: ["renovate/npm"],
+    },
   ],
 }

--- a/.renovate/semanticCommits.json5
+++ b/.renovate/semanticCommits.json5
@@ -43,5 +43,10 @@
       semanticCommitScope: "github-release",
       commitMessageTopic: "release {{depName}}",
     },
+    {
+      matchDatasources: ["npm"],
+      semanticCommitScope: "npm",
+      commitMessageTopic: "package {{depName}}",
+    },
   ],
 }

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
@@ -45,6 +45,7 @@ spec:
             - npx
           args:
             - -y
+            # renovate: datasource=npm depName=mcp-arr-server
             - mcp-arr-server@1.5.4
           volumeMounts:
             - name: tmp

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/mcpserver.yaml
@@ -35,7 +35,8 @@ spec:
             - npx
           args:
             - -y
-            - "@jhomen368/overseerr-mcp"
+            # renovate: datasource=npm depName=@jhomen368/overseerr-mcp
+            - "@jhomen368/overseerr-mcp@2.2.0"
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/kubernetes/apps/ai/toolhive/mcp-servers/todoist-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/todoist-mcp/mcpserver.yaml
@@ -36,7 +36,8 @@ spec:
           args:
             - -y
             - -p
-            - "@doist/todoist-mcp@10.1.5"
+            # renovate: datasource=npm depName=@doist/todoist-mcp
+            - "@doist/todoist-mcp@10.4.1"
             - --
             - todoist-mcp-http
           volumeMounts:


### PR DESCRIPTION
Add a custom regex manager so Renovate can update npm packages referenced inside npx args of MCPServer manifests, via an explicit
  # renovate: datasource=npm depName=<pkg>
annotation.

- customManagers: new regex matching '<pkg>@<version>' list items
- labels: add renovate/npm label for npm datasource
- semanticCommits: scope 'npm', topic 'package {{depName}}'
- changelogs: pin upstream repo URLs for todoist-mcp, mcp-arr-server, overseerr-mcp
- autoMerge: automerge minor/patch npm updates (branch strategy)
- labels.yaml: declare renovate/npm GitHub label
- todoist-mcp: annotate @doist/todoist-mcp@10.4.1
- arr-mcp: annotate mcp-arr-server@1.5.4
- seerr-mcp: pin @jhomen368/overseerr-mcp@2.2.0 and annotate