### PR TITLE
feat(ai): add lightrag-mcp server to toolhive

### DIFF
--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -369,3 +369,29 @@ spec:
     namespace: flux-system
   targetNamespace: ai
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name lightrag-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  dependsOn:
+    - name: toolhive
+    - name: lightrag
+      namespace: ai
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-lightrag
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        LIGHTRAG_API_KEY: "{{ .LIGHTRAG_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: lightrag

--- a/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/mcpserver.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: lightrag-mcp
+spec:
+  image: ghcr.io/astral-sh/uv:python3.12-alpine
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: LIGHTRAG_HOST
+      value: lightrag.ai.svc.cluster.local
+    - name: LIGHTRAG_PORT
+      value: "9621"
+  secrets:
+    - name: toolhive-lightrag
+      key: LIGHTRAG_API_KEY
+      targetEnvName: LIGHTRAG_API_KEY
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          command:
+            - uvx
+          args:
+            # renovate: datasource=pypi depName=mcp-lightrag
+            - mcp-lightrag==0.2.2
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  groupRef:
+    name: mcp-tools


### PR DESCRIPTION
## Summary

Add an MCP server wrapping the existing LightRAG REST API so mainclaw can interface with the knowledge graph through toolhive.

## Changes

- **New**: `kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/mcpserver.yaml` — `MCPServer` running `uvx mcp-lightrag==0.2.2` (`ghcr.io/astral-sh/uv:python3.12-alpine`), stdio + streamable-http proxy, connected to `lightrag.ai.svc.cluster.local:9621`, in group `mcp-tools`
- **New**: `externalsecret.yaml` — extracts `LIGHTRAG_API_KEY` from 1Password item `lightrag` (same source as the lightrag app)
- **New**: `kustomization.yaml` — references both resources
- **Modified**: `kubernetes/apps/ai/toolhive/ks.yaml` — added Flux Kustomization `lightrag-mcp` with `dependsOn: toolhive` + `lightrag`

## How it works

```
mainclaw → vmcp-mcp-gateway-internal (mcp-tools group) → lightrag-mcp pod → lightrag API (port 9621)
```

Once Flux reconciles, the 18 LightRAG tools (query, ingest, upsert, graph operations) are exposed to mainclaw through the existing `mcp-gateway-internal` virtual server — no changes needed to `openclaw.json`.

## Implementation choice

No official MCP server exists for LightRAG (HKUDS/LightRAG does not mention MCP anywhere). Selected [`mcp-lightrag`](https://github.com/enriquecatala/mcp-lightrag) (v0.2.2, MIT) — the most recently maintained community server (last updated 2026-05-11), with smart document upsert support.

## Validation

```
flate test ks --path ./kubernetes/apps   → 102 passed
flate test hr --path ./kubernetes/apps   →  81 passed
```