### PR TITLE
fix(ai): switch todoist-mcp to stdio transport

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/todoist-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/todoist-mcp/mcpserver.yaml
@@ -6,7 +6,7 @@ metadata:
   name: todoist-mcp
 spec:
   image: docker.io/node:24-alpine
-  transport: streamable-http
+  transport: stdio
   proxyMode: streamable-http
   proxyPort: 8080
   env:
@@ -14,8 +14,6 @@ spec:
       value: /tmp
     - name: NPM_CONFIG_CACHE
       value: /tmp/.npm
-    - name: PORT
-      value: "8080"
   secrets:
     - name: toolhive-todoist
       key: TODOIST_API_KEY
@@ -39,7 +37,7 @@ spec:
             # renovate: datasource=npm depName=@doist/todoist-mcp
             - "@doist/todoist-mcp@10.4.2"
             - --
-            - todoist-mcp-http
+            - todoist-mcp
           volumeMounts:
             - name: tmp
               mountPath: /tmp


### PR DESCRIPTION
The workload bound on 127.0.0.1:8080 (npm default), refusing connections from the proxy pod via the ClusterIP Service, causing persistent "connection refused" errors.

Switch to stdio transport (matching arr-mcp, seerr-mcp, memory-mcp pattern) so the proxy talks to the workload over stdin/stdout and use the stdio binary "todoist-mcp" instead of "todoist-mcp-http".