### PR TITLE
feat(ai): add lightrag-mcp server to toolhive

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/mcpserver.yaml
@@ -28,11 +28,17 @@ spec:
     spec:
       containers:
         - name: mcp
+          image: ghcr.io/astral-sh/uv:python3.12-alpine
           command:
             - uvx
           args:
             # renovate: datasource=pypi depName=mcp-lightrag
             - mcp-lightrag==0.2.2
+          env:
+            - name: HOME
+              value: /tmp
+            - name: UV_CACHE_DIR
+              value: /tmp/.uv-cache
           volumeMounts:
             - name: tmp
               mountPath: /tmp


### PR DESCRIPTION
## Summary

Add an MCP server wrapping the existing LightRAG REST API so mainclaw can interface with the knowledge graph through toolhive.

## Changes

- **New**: `kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/mcpserver.yaml` — `MCPServer` running `uvx mcp-lightrag==0.2.2` (`ghcr.io/astral-sh/uv:python3.12-alpine`), stdio + streamable-http proxy, connected to `lightrag.ai.svc.cluster.local:9621`, in group `mcp-tools`
- **New**: `externalsecret.yaml` — extracts `LIGHTRAG_API_KEY` from 1Password item `lightrag` (same source as the lightrag app)
- **New**: `kustomization.yaml` — references both resources
- **Modified**: `kubernetes/apps/ai/toolhive/ks.yaml` — added Flux Kustomization `lightrag-mcp` with `dependsOn: toolhive` + `lightrag`

## How it works

```
mainclaw → vmcp-mcp-gateway-internal (mcp-tools group) → lightrag-mcp pod → lightrag API (port 9621)
```

Once Flux reconciles, the 18 LightRAG tools (query, ingest, upsert, graph operations) are exposed to mainclaw through the existing `mcp-gateway-internal` virtual server — no changes needed to `openclaw.json`.

## Implementation choice

No official MCP server exists for LightRAG (HKUDS/LightRAG does not mention MCP anywhere). Selected [`mcp-lightrag`](https://github.com/enriquecatala/mcp-lightrag) (v0.2.2, MIT) — the most recently maintained community server (last updated 2026-05-11), with smart document upsert support.

## Validation

```
flate test ks --path ./kubernetes/apps   → 102 passed
flate test hr --path ./kubernetes/apps   →  81 passed
```