### PR TITLE
feat(ai): deploy memini memory service for mainclaw and devclaw

### DIFF
--- a/kubernetes/apps/ai/devclaw/app/resources/openclaw.json
+++ b/kubernetes/apps/ai/devclaw/app/resources/openclaw.json
@@ -283,6 +283,7 @@
       "lossless-claw",
       "memory-core",
       "memory-wiki",
+      "memini",
       "oc-path",
       "searxng",
       "thread-ownership",
@@ -397,13 +398,30 @@
           }
         }
       },
+      "memini": {
+        "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
+        "config": {
+          "base_url": "http://memini.ai:8080",
+          "namespace": "devclaw",
+          "namespace_per_agent": true,
+          "skip_without_agent": true,
+          "skip_system_turns": true,
+          "fallback_on_error": true,
+          "timeout_ms": 15000,
+          "recall_limit": 3,
+          "expose_tools": true
+        }
+      },
       "thread-ownership": { "enabled": true },
       "tokenjuice": { "enabled": true },
       "web-readability": { "enabled": true }
     },
     "slots": {
       "contextEngine": "lossless-claw",
-      "memory": "memory-core"
+      "memory": "memini"
     }
   },
   "session": {

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
   - ./headroom/ks.yaml
   - ./lightrag/ks.yaml
   - ./litellm/ks.yaml
+  - ./llmkube/ks.yaml
   - ./mainclaw/ks.yaml
+  - ./memini/ks.yaml
   - ./searxng/ks.yaml
   - ./toolhive/ks.yaml

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llmkube
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: llmkube
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    modelCache:
+      enabled: true
+      mode: perService
+      size: 10Gi
+      storageClass: openebs-hostpath
+    prometheus:
+      inferencePodMonitor:
+        enabled: true

--- a/kubernetes/apps/ai/llmkube/app/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: llmkube
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.9.3
+  url: oci://ghcr.io/defilantech/charts/llmkube

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: llmkube
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: llmkube
+  interval: 1h
+  path: ./kubernetes/apps/ai/llmkube/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: llmkube-models
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: llmkube-models
+  dependsOn:
+    - name: llmkube
+  interval: 1h
+  path: ./kubernetes/apps/ai/llmkube/models
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./qwen3-embedding-0.6b.yaml
+  - ./qwen3-reranker-0.6b.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/model_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-embedding-0.6b
+spec:
+  format: gguf
+  quantization: Q8_0
+  source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
+  hardware:
+    accelerator: cuda
+    gpu:
+      count: 1
+      enabled: true
+      layers: 99
+      vendor: nvidia
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen3-embedding-0.6b
+spec:
+  modelRef: qwen3-embedding-0.6b
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:ae35c11fb24b9478053a7ba6ab71d80a9937f3b5c7f6003ef12fe4b937b151f5
+  runtimeClassName: nvidia
+  replicas: 1
+  nodeSelector:
+    kubernetes.io/hostname: k8s-3
+  tolerations:
+    - key: workload
+      operator: Equal
+      value: ai
+      effect: NoSchedule
+  contextSize: 4096
+  parallelSlots: 1
+  batchSize: 4096
+  uBatchSize: 4096
+  resources:
+    gpu: 1
+    cpu: 100m
+    memory: 1Gi
+  extraArgs:
+    - --embeddings
+    - --pooling
+    - last
+    - --cache-ram
+    - "0"
+    - --no-mmap
+    - --alias
+    - qwen3-embedding-0.6b
+    - --metrics
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 60
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 30
+      failureThreshold: 3
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 3

--- a/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/model_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-reranker-0.6b
+spec:
+  format: gguf
+  quantization: Q8_0
+  source: https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/main/qwen3-reranker-0.6b-q8_0.gguf
+  hardware:
+    accelerator: cuda
+    gpu:
+      count: 1
+      enabled: true
+      layers: 99
+      vendor: nvidia
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen3-reranker-0.6b
+spec:
+  modelRef: qwen3-reranker-0.6b
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:ae35c11fb24b9478053a7ba6ab71d80a9937f3b5c7f6003ef12fe4b937b151f5
+  runtimeClassName: nvidia
+  replicas: 1
+  nodeSelector:
+    kubernetes.io/hostname: k8s-3
+  tolerations:
+    - key: workload
+      operator: Equal
+      value: ai
+      effect: NoSchedule
+  contextSize: 4096
+  parallelSlots: 1
+  batchSize: 4096
+  uBatchSize: 4096
+  resources:
+    gpu: 1
+    cpu: 100m
+    memory: 1Gi
+  extraArgs:
+    - --rerank
+    - --pooling
+    - rank
+    - --cache-ram
+    - "0"
+    - --no-mmap
+    - --alias
+    - qwen3-reranker-0.6b
+    - --metrics
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 60
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 30
+      failureThreshold: 3
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 3

--- a/kubernetes/apps/ai/mainclaw/app/resources/openclaw.json
+++ b/kubernetes/apps/ai/mainclaw/app/resources/openclaw.json
@@ -1039,6 +1039,7 @@
       "lossless-claw",
       "memory-core",
       "memory-wiki",
+      "memini",
       "searxng",
       "thread-ownership",
       "tokenjuice",
@@ -1173,6 +1174,23 @@
           }
         }
       },
+      "memini": {
+        "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
+        "config": {
+          "base_url": "http://memini.ai:8080",
+          "namespace": "mainclaw",
+          "namespace_per_agent": true,
+          "skip_without_agent": true,
+          "skip_system_turns": true,
+          "fallback_on_error": true,
+          "timeout_ms": 15000,
+          "recall_limit": 3,
+          "expose_tools": true
+        }
+      },
       "thread-ownership": {
         "enabled": true,
         "config": {}
@@ -1188,7 +1206,7 @@
     },
     "slots": {
       "contextEngine": "lossless-claw",
-      "memory": "memory-core"
+      "memory": "memini"
     }
   },
   "secrets": {

--- a/kubernetes/apps/ai/memini/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/memini/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name memini
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
+        MEMINI_LLM_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+  dataFrom:
+    - extract:
+        key: memini
+    - extract:
+        key: litellm

--- a/kubernetes/apps/ai/memini/app/grafanadashboard.yaml
+++ b/kubernetes/apps/ai/memini/app/grafanadashboard.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: memini
+spec:
+  allowCrossNamespaceImport: true
+  folderRef: "ai"
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: memini-memini
+    key: memini.json

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app memini
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 15m
+  upgrade:
+    force: true
+  values:
+    global:
+      fullnameOverride: *app
+    controllers:
+      main:
+        containers:
+          main:
+            env:
+              MEMINI_BACKEND: sqlite
+              MEMINI_DEFAULT_NAMESPACE: default
+              MEMINI_EMBED_BASE_URL: http://qwen3-embedding-0.6b.ai.svc.cluster.local:8080/v1
+              MEMINI_EMBED_MODEL: qwen3-embedding-0.6b
+              MEMINI_EMBED_DIMS: "1024"
+              MEMINI_EMBED_QUERY_PREFIX: "Instruct: Given a user message, retrieve relevant past memories\nQuery: "
+              MEMINI_EMBED_MAX_CONCURRENCY: "2"
+              MEMINI_RECALL_EMBED_TIMEOUT: 10s
+              MEMINI_RERANK: http://qwen3-reranker-0.6b.ai.svc.cluster.local:8080/v1
+              MEMINI_RERANK_MODEL: qwen3-reranker-0.6b
+              MEMINI_RERANK_MAX_CONCURRENCY: "2"
+              MEMINI_RERANK_TIMEOUT: 8s
+              MEMINI_WRITE_DEDUP_SCORE: "0.80"
+              MEMINI_WRITE_DEDUP_ACTION: coalesce
+              MEMINI_LLM_BASE_URL: http://litellm.ai:4000/v1
+              MEMINI_LLM_MODEL: dsv4f
+              MEMINI_LLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: *app
+                    key: MEMINI_LLM_API_KEY
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: *app
+                    key: MEMINI_API_KEY
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 180
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+      fsck:
+        enabled: true
+        cronjob:
+          schedule: "0 5 * * *"
+        containers:
+          fsck:
+            env:
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: *app
+                    key: MEMINI_API_KEY
+    persistence:
+      data:
+        existingClaim: *app
+    serviceMonitor:
+      main:
+        enabled: true
+    grafanaDashboards:
+      enabled: true
+      folder: ai
+    route:
+      ui:
+        enabled: true
+        hostnames:
+          - memini.oxygn.dev
+        parentRefs:
+          - name: envoy-internal
+            namespace: network

--- a/kubernetes/apps/ai/memini/app/kustomization.yaml
+++ b/kubernetes/apps/ai/memini/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/ai/memini/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/memini/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: memini
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v0.6.2
+  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app memini
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: llmkube-models
+    - name: litellm
+  interval: 1h
+  path: ./kubernetes/apps/ai/memini/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Add llmkube operator (v0.9.3) with Qwen3-Embedding-0.6B and Qwen3-Reranker-0.6B InferenceServices on k8s-3 (NVIDIA CUDA, time-sliced GPU). Deploy memini (v0.6.2) as a SQLite-backed StatefulSet with volsync backup, using llmkube for embeddings + reranking and litellm (dsv4f) for LLM consolidation. Configure the memini plugin on both mainclaw and devclaw OpenClaw instances with per-agent namespaces, replacing memory-core as the memory slot.