### PR TITLE
feat(ai): install memini plugin in mainclaw and devclaw

### DIFF
--- a/kubernetes/apps/ai/devclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/devclaw/app/helmrelease.yaml
@@ -41,6 +41,18 @@ spec:
               - /bin/sh
               - -c
               - |
+                # Install the memini memory plugin from ClawHub, version-guarded:
+                # only fetches when the pinned version differs from what's on the
+                # persistent volume, so normal restarts stay offline.
+                # renovate: datasource=github-tags depName=eleboucher/memini
+                MEMINI_PLUGIN_VERSION=0.6.2
+                if [ "$(cat "$HOME/.openclaw/extensions/memini/.clawver" 2>/dev/null)" != "$MEMINI_PLUGIN_VERSION" ]; then
+                  if node dist/index.js plugins install "clawhub:@eleboucher/memini@$MEMINI_PLUGIN_VERSION" --pin --force; then
+                    printf '%s' "$MEMINI_PLUGIN_VERSION" > "$HOME/.openclaw/extensions/memini/.clawver"
+                  else
+                    echo "WARN: memini plugin install failed; starting with whatever is present"
+                  fi
+                fi
                 # Start gateway
                 echo "Starting OpenClaw gateway..."
                 exec node dist/index.js gateway

--- a/kubernetes/apps/ai/devclaw/app/resources/openclaw.json
+++ b/kubernetes/apps/ai/devclaw/app/resources/openclaw.json
@@ -97,6 +97,13 @@
         "identity": {
           "name": "Puchu",
           "emoji": "🛠️"
+        },
+        "tools": {
+          "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember"
+          ]
         }
       }
     ]

--- a/kubernetes/apps/ai/mainclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/mainclaw/app/helmrelease.yaml
@@ -46,6 +46,18 @@ spec:
               - /bin/sh
               - -c
               - |
+                # Install the memini memory plugin from ClawHub, version-guarded:
+                # only fetches when the pinned version differs from what's on the
+                # persistent volume, so normal restarts stay offline.
+                # renovate: datasource=github-tags depName=eleboucher/memini
+                MEMINI_PLUGIN_VERSION=0.6.2
+                if [ "$(cat "$HOME/.openclaw/extensions/memini/.clawver" 2>/dev/null)" != "$MEMINI_PLUGIN_VERSION" ]; then
+                  if node dist/index.js plugins install "clawhub:@eleboucher/memini@$MEMINI_PLUGIN_VERSION" --pin --force; then
+                    printf '%s' "$MEMINI_PLUGIN_VERSION" > "$HOME/.openclaw/extensions/memini/.clawver"
+                  else
+                    echo "WARN: memini plugin install failed; starting with whatever is present"
+                  fi
+                fi
                 # Start gateway
                 echo "Starting OpenClaw gateway..."
                 exec node dist/index.js gateway

--- a/kubernetes/apps/ai/mainclaw/app/resources/openclaw.json
+++ b/kubernetes/apps/ai/mainclaw/app/resources/openclaw.json
@@ -183,6 +183,9 @@
         "tools": {
           "profile": "full",
           "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember",
             "browser",
             "message",
             "gateway",
@@ -221,6 +224,9 @@
         "tools": {
           "profile": "full",
           "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember",
             "message",
             "agents_list",
             "wiki_apply",
@@ -262,6 +268,9 @@
         "tools": {
           "profile": "full",
           "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember",
             "message",
             "wiki_apply",
             "wiki_get",
@@ -303,6 +312,9 @@
         "tools": {
           "profile": "full",
           "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember",
             "message",
             "wiki_get",
             "wiki_lint",
@@ -344,6 +356,9 @@
         "tools": {
           "profile": "full",
           "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember",
             "wiki_apply",
             "wiki_status",
             "wiki_get",
@@ -386,6 +401,9 @@
         "tools": {
           "profile": "full",
           "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember",
             "message"
           ],
           "exec": {
@@ -430,6 +448,9 @@
         "tools": {
           "profile": "full",
           "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember",
             "message",
             "agents_list"
           ],
@@ -512,6 +533,9 @@
         "tools": {
           "profile": "full",
           "alsoAllow": [
+            "memory_recall",
+            "memory_list",
+            "memory_remember",
             "message",
             "agents_list",
             "sessions_send",


### PR DESCRIPTION
Add the ClawHub memini plugin installation step (version-guarded) to the OpenClaw container startup command in both instances, and grant memory_recall/memory_list/memory_remember tools to all agents.