### PR TITLE
feat(litellm): add z.ai GLM Coding Lite models

### DIFF
--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -17,6 +17,7 @@ spec:
         # API
         OPENCODE_API_KEY: "{{ .OPENCODE_API_KEY }}"
         MINIMAX_API_KEY: '{{ .MINIMAX_API_KEY }}'
+        ZAI_API_KEY: "{{ .ZAI_API_KEY }}"
   dataFrom:
     - extract:
         key: litellm

--- a/kubernetes/apps/ai/litellm/app/resources/config.yaml
+++ b/kubernetes/apps/ai/litellm/app/resources/config.yaml
@@ -135,6 +135,43 @@ model_list:
       api_base: https://opencode.ai/zen/go/v1
       api_key: os.environ/OPENCODE_API_KEY
 
+  # z.ai GLM Coding Lite plan (direct, dedicated endpoint)
+  - model_name: zai-glm-5.2
+    model_info:
+      mode: chat
+      max_input_tokens: 1000000
+      max_output_tokens: 131072
+      supports_function_calling: true
+      supports_prompt_caching: true
+    litellm_params:
+      model: openai/glm-5.2
+      api_base: https://api.z.ai/api/coding/paas/v4
+      api_key: os.environ/ZAI_API_KEY
+
+  - model_name: zai-glm-4.7
+    model_info:
+      mode: chat
+      max_input_tokens: 204800
+      max_output_tokens: 131072
+      supports_function_calling: true
+      supports_prompt_caching: true
+    litellm_params:
+      model: openai/glm-4.7
+      api_base: https://api.z.ai/api/coding/paas/v4
+      api_key: os.environ/ZAI_API_KEY
+
+  - model_name: zai-glm-5-turbo
+    model_info:
+      mode: chat
+      max_input_tokens: 204800
+      max_output_tokens: 131072
+      supports_function_calling: true
+      supports_prompt_caching: true
+    litellm_params:
+      model: openai/glm-5-turbo
+      api_base: https://api.z.ai/api/coding/paas/v4
+      api_key: os.environ/ZAI_API_KEY
+
 general_settings:
   health_check_endpoint: /v1/health
 
@@ -148,6 +185,7 @@ router_settings:
     - MiniMax-M3: ["go-minimax-m3"]
     - MiniMax-M2.7: ["go-minimax-m2.7"]
     - dsv4f: ["go-minimax-m3"]
+    - zai-glm-5.2: ["zai-glm-4.7"]
 
 litellm_settings:
   callbacks: ["prometheus"]
@@ -169,5 +207,6 @@ litellm_settings:
 environment:
   - MINIMAX_API_KEY
   - OPENCODE_API_KEY
+  - ZAI_API_KEY
   - REDIS_HOST
   - REDIS_PORT


### PR DESCRIPTION
## Summary

Add the z.ai GLM Coding Lite subscription models to litellm, using the dedicated Coding Plan endpoint (`https://api.z.ai/api/coding/paas/v4`).

## Models added

| `model_name` | Upstream model | Context | Max output | Notes |
|---|---|---|---|---|
| `zai-glm-5.2` | glm-5.2 | 1M | 128K | Flagship, 2-3x quota on Lite plan |
| `zai-glm-4.7` | glm-4.7 | 200K | 128K | Cost 1x — efficient fallback |
| `zai-glm-5-turbo` | glm-5-turbo | 200K | 128K | Optimized for agent / OpenClaw chains |

All three are text-only (no vision flag), support function calling and prompt caching.

## Router

- Added fallback `zai-glm-5.2 -> [zai-glm-4.7]` so quota-exhaustion on 5.2 degrades to the cheaper 4.7 instead of failing.

## Secrets

- `ZAI_API_KEY` is sourced from the existing 1Password item `litellm` (field `ZAI_API_KEY`, added by the user out-of-band).
- Updated `externalsecret.yaml` template + the litellm `environment:` allow-list.
- No plaintext secrets in Git. `dataFrom.extract.key: litellm` already pulls every field from the 1Password item.

## Validation

- `flate test ks --path ./kubernetes/apps/ai` -> ai/litellm passes (14 passed, 11 blocked by unrelated missing deps in this worktree).
- `flate test hr --path ./kubernetes/apps/ai/litellm/app` -> blocked locally by the OCIRepository pull (same on main; CI will resolve).
- YAML syntax verified.

## Notes for reviewers

- The pre-existing `glm-5.1` entry routes via the OpenCode zen/go gateway (`OPENCODE_API_KEY`) and is intentionally left untouched — it is orthogonal to this direct z.ai integration.
- `reloader.stakater.com/auto: "true"` on the deployment will roll the pod once the ConfigMap and Secret sync.
- No HelmRelease values, kustomization, or ks.yaml changes needed.