### PR TITLE
feat(devclaw): use z.ai GLM 5.2 for main devops agent

### DIFF
--- a/kubernetes/apps/ai/devclaw/app/resources/openclaw.json
+++ b/kubernetes/apps/ai/devclaw/app/resources/openclaw.json
@@ -11,6 +11,7 @@
       "contextInjection": "always",
       "contextPruning": { "mode": "off" },
       "heartbeat": {
+        "model": "litellm/MiniMax-M3",
         "directPolicy": "allow",
         "includeReasoning": false,
         "isolatedSession": true,
@@ -32,11 +33,10 @@
         }
       },
       "model": {
-        "primary": "litellm/MiniMax-M3",
+        "primary": "litellm/zai-glm-5.2",
         "fallbacks": [
-          "litellm/go-minimax-m3",
-          "litellm/dsv4f",
-          "litellm/go-kimi-k2.6"
+          "litellm/zai-glm-4.7",
+          "litellm/MiniMax-M3"
         ]
       },
       "imageModel": {
@@ -51,6 +51,8 @@
         "litellm/dsv4f": { "alias": "dsv4f", "params": { "cache_prompt": true } },
         "litellm/dsv4p": { "alias": "dsv4p", "params": { "cache_prompt": true } },
         "litellm/glm-5.1": { "alias": "glm-5.1", "params": { "cache_prompt": true } },
+        "litellm/zai-glm-5.2": { "alias": "glm-5.2", "params": { "cache_prompt": true } },
+        "litellm/zai-glm-4.7": { "alias": "glm-4.7", "params": { "cache_prompt": true } },
         "litellm/go-kimi-k2.6": { "alias": "go-kimi-2.6", "params": { "cache_prompt": true } },
         "litellm/go-minimax-m3": { "alias": "go-minimax-m3", "params": { "cache_prompt": true } },
         "litellm/go-minimax-m2.7": { "alias": "go-minimax-m2.7", "params": { "cache_prompt": true } },
@@ -272,7 +274,9 @@
           { "id": "go-kimi-k2.6", "name": "OpenCode Go Kimi K2.6", "reasoning": true, "input": ["text"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 262144, "maxTokens": 16384 },
           { "id": "go-minimax-m3", "name": "OpenCode Go MiniMax M3", "reasoning": true, "input": ["text"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1000000, "maxTokens": 32768 },
           { "id": "go-minimax-m2.7", "name": "OpenCode Go MiniMax M2.7", "reasoning": true, "input": ["text"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 204800, "maxTokens": 16384 },
-          { "id": "mimo-v2.5-pro", "name": "OpenCode Go MiMo V2.5 Pro", "reasoning": true, "input": ["text"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 262144, "maxTokens": 16384 }
+          { "id": "mimo-v2.5-pro", "name": "OpenCode Go MiMo V2.5 Pro", "reasoning": true, "input": ["text"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 262144, "maxTokens": 16384 },
+          { "id": "zai-glm-5.2", "name": "z.ai GLM 5.2", "reasoning": true, "input": ["text"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1000000, "maxTokens": 131072 },
+          { "id": "zai-glm-4.7", "name": "z.ai GLM 4.7", "reasoning": true, "input": ["text"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 204800, "maxTokens": 131072 }
         ]
       }
     }


### PR DESCRIPTION
## Summary

Switch the primary **devclaw** devops agent (Puchu) from `MiniMax-M3` to **z.ai GLM 5.2** (via litellm), while keeping **MiniMax-M3 for heartbeat**.

## Changes

All changes in `kubernetes/apps/ai/devclaw/app/resources/openclaw.json`:

| Section | Before | After |
| --- | --- | --- |
| `agents.defaults.model.primary` | `litellm/MiniMax-M3` | `litellm/zai-glm-5.2` |
| `agents.defaults.model.fallbacks` | `go-minimax-m3, dsv4f, go-kimi-k2.6` | `zai-glm-4.7, MiniMax-M3` |
| `agents.defaults.heartbeat.model` | _(unset, inherited)_ | `litellm/MiniMax-M3` (explicit) |
| `agents.defaults.models` catalog | — | added `zai-glm-5.2`, `zai-glm-4.7` |
| `models.providers.litellm.models` | — | added `zai-glm-5.2`, `zai-glm-4.7` |

### Unchanged

- **Heartbeat**: stays on `MiniMax-M3` (explicit `heartbeat.model` override).
- **Subagents**: stay on `MiniMax-M3` (cheaper/faster for delegated work).
- **imageModel**: stays on `MiniMax-M3` (litellm `zai-glm-5.2` does not declare `supports_vision`).
- **Secrets**: no change. devclaw talks to litellm via `LITELLM_API_KEY`; `ZAI_API_KEY` is consumed by litellm (provisioned in `litellm/app/externalsecret.yaml`).

## Prerequisites

Depends on litellm `zai-glm-5.2` / `zai-glm-4.7` model definitions (already merged in #3476).

## Verification

- JSON syntax: valid
- `flate test hr --path ./kubernetes/apps`: 84 passed, 0 failures
- OpenClaw config schema: `heartbeat.model` is a documented optional field (`provider/model` format)

## Notes

- `cost` set to `0` for the z.ai models in the openclaw catalog (Coding Lite is a flat-rate plan). Adjust if per-token tracking is desired.
- After merge, Flux reconciles `devclaw`. Config is mounted via Secret (`devclaw-config`, 1m refresh) with Stakater reloader annotations, so the pod hot-reloads `openclaw.json` automatically.