### PR TITLE
fix(memini): correct embedder/reranker service hostnames

### DIFF
--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -21,13 +21,13 @@ spec:
             env:
               MEMINI_BACKEND: sqlite
               MEMINI_DEFAULT_NAMESPACE: default
-              MEMINI_EMBED_BASE_URL: http://qwen3-embedding-0.6b.ai.svc.cluster.local:8080/v1
+              MEMINI_EMBED_BASE_URL: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080/v1
               MEMINI_EMBED_MODEL: qwen3-embedding-0.6b
               MEMINI_EMBED_DIMS: "1024"
               MEMINI_EMBED_QUERY_PREFIX: "Instruct: Given a user message, retrieve relevant past memories\nQuery: "
               MEMINI_EMBED_MAX_CONCURRENCY: "2"
               MEMINI_RECALL_EMBED_TIMEOUT: 10s
-              MEMINI_RERANK: http://qwen3-reranker-0.6b.ai.svc.cluster.local:8080/v1
+              MEMINI_RERANK: http://qwen3-reranker-0-6b.ai.svc.cluster.local:8080/v1
               MEMINI_RERANK_MODEL: qwen3-reranker-0.6b
               MEMINI_RERANK_MAX_CONCURRENCY: "2"
               MEMINI_RERANK_TIMEOUT: 8s


### PR DESCRIPTION
memini pointed at qwen3-embedding-0.6b and qwen3-reranker-0.6b (dots), but llmkube creates Services with dots replaced by dashes. The dotted names do not resolve in cluster DNS, causing:
  - embedder: context deadline exceeded (10s timeout drained by DNS retries)
  - reranker:  no such host (NXDOMAIN)
  - 1285 vectorless memories piling up while the embedder is down

Switch both URLs to the dashed Service names that llmkube actually publishes (confirmed via InferenceService.status.endpoint and kubectl get svc). Model names (MEMINI_EMBED_MODEL / MEMINI_RERANK_MODEL) keep their dots since llamacpp aliases the model with the dotted name.