### PR TITLE
fix(ai): restore GPU for memini embedder/reranker + tune timeouts

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -8,6 +8,13 @@ spec:
   format: gguf
   quantization: Q8_0
   source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
+  hardware:
+    accelerator: cuda
+    gpu:
+      count: 1
+      enabled: true
+      layers: 99
+      vendor: nvidia
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -17,7 +24,8 @@ metadata:
 spec:
   modelRef: qwen3-embedding-0.6b
   runtime: llamacpp
-  image: ghcr.io/ggml-org/llama.cpp:server
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:ae35c11fb24b9478053a7ba6ab71d80a9937f3b5c7f6003ef12fe4b937b151f5
+  runtimeClassName: nvidia
   replicas: 1
   nodeSelector:
     kubernetes.io/hostname: k8s-3
@@ -31,14 +39,16 @@ spec:
   batchSize: 4096
   uBatchSize: 4096
   resources:
+    gpu: 1
     cpu: 100m
-    memory: 2Gi
+    memory: 1Gi
   extraArgs:
     - --embeddings
     - --pooling
     - last
     - --cache-ram
-    - "512"
+    - "0"
+    - --no-mmap
     - --alias
     - qwen3-embedding-0.6b
     - --metrics

--- a/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
@@ -8,6 +8,13 @@ spec:
   format: gguf
   quantization: Q8_0
   source: https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/main/qwen3-reranker-0.6b-q8_0.gguf
+  hardware:
+    accelerator: cuda
+    gpu:
+      count: 1
+      enabled: true
+      layers: 99
+      vendor: nvidia
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -17,7 +24,8 @@ metadata:
 spec:
   modelRef: qwen3-reranker-0.6b
   runtime: llamacpp
-  image: ghcr.io/ggml-org/llama.cpp:server
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:ae35c11fb24b9478053a7ba6ab71d80a9937f3b5c7f6003ef12fe4b937b151f5
+  runtimeClassName: nvidia
   replicas: 1
   nodeSelector:
     kubernetes.io/hostname: k8s-3
@@ -31,14 +39,16 @@ spec:
   batchSize: 4096
   uBatchSize: 4096
   resources:
+    gpu: 1
     cpu: 100m
-    memory: 2Gi
+    memory: 1Gi
   extraArgs:
     - --rerank
     - --pooling
     - rank
     - --cache-ram
-    - "512"
+    - "0"
+    - --no-mmap
     - --alias
     - qwen3-reranker-0.6b
     - --metrics

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -25,12 +25,12 @@ spec:
               MEMINI_EMBED_MODEL: qwen3-embedding-0.6b
               MEMINI_EMBED_DIMS: "1024"
               MEMINI_EMBED_QUERY_PREFIX: "Instruct: Given a user message, retrieve relevant past memories\nQuery: "
-              MEMINI_EMBED_MAX_CONCURRENCY: "2"
-              MEMINI_RECALL_EMBED_TIMEOUT: 10s
+              MEMINI_EMBED_MAX_CONCURRENCY: "1"
+              MEMINI_RECALL_EMBED_TIMEOUT: 60s
               MEMINI_RERANK: http://qwen3-reranker-0-6b.ai.svc.cluster.local:8080/v1
               MEMINI_RERANK_MODEL: qwen3-reranker-0.6b
-              MEMINI_RERANK_MAX_CONCURRENCY: "2"
-              MEMINI_RERANK_TIMEOUT: 8s
+              MEMINI_RERANK_MAX_CONCURRENCY: "1"
+              MEMINI_RERANK_TIMEOUT: 30s
               MEMINI_WRITE_DEDUP_SCORE: "0.80"
               MEMINI_WRITE_DEDUP_ACTION: coalesce
               MEMINI_LLM_BASE_URL: http://litellm.ai:4000/v1


### PR DESCRIPTION
## Summary

Follow-up to #3531 (DNS fix). The embedder was still failing because it runs on CPU while 4 NVIDIA GPUs sit idle on `k8s-3`. This restores CUDA for both inference services and tunes memini's concurrency/timeouts to match.

## Root cause

After PR #3531 corrected the hostnames, a new bottleneck surfaced:

| Input size | CPU latency | Issue (`MEMINI_RECALL_EMBED_TIMEOUT: 10s`) |
|---|---|---|
| 3 tok | 0.4s | OK |
| ~400 tok | 7-8s | borderline |
| ~470 tok | 10s | timeout |
| ~1640 tok | **34s** | always cancelled mid-flight |

llamacpp logs showed cascading `cancel task` entries — the client killed requests that were still being processed. memini also sends concurrency=2 against the server's `parallelSlots: 1`, so the queued second request burned its 10s budget waiting and was cancelled before even starting.

`kubectl top pod` showed `qwen3-embedding-0.6b` at **5371m CPU** on `k8s-0` (control-plane, contended with etcd/Ceph), and `kubectl describe node k8s-3` showed `nvidia.com/gpu: 0/4` allocated — **4 idle GPUs**.

Commit `5f748441e` (10 Jul) demoted both services from GPU to CPU the same day the `nvidia-device-plugin` was first deployed. The plugin has been stable for 5 days and no workload uses the GPU, so the original CUDA config can be restored.

## Changes

### `llmkube/models/qwen3-embedding-0.6b.yaml` + `qwen3-reranker-0.6b.yaml`

Restored pre-`5f748441e` CUDA configuration:
- `hardware.accelerator: cuda` with `gpu: {count: 1, layers: 99, vendor: nvidia}` on the `Model`
- `image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:ae35c11f…` (digest verified present on GHCR via HTTP 200)
- `runtimeClassName: nvidia`
- `resources.gpu: 1` (+ restore `memory: 1Gi`)
- `--cache-ram 0 --no-mmap` for fully VRAM-resident inference

### `memini/app/helmrelease.yaml`

Tune to match the new compute profile and avoid queue-induced cancels:
- `MEMINI_EMBED_MAX_CONCURRENCY: 2 → 1` (match `parallelSlots: 1`)
- `MEMINI_RERANK_MAX_CONCURRENCY: 2 → 1`
- `MEMINI_RECALL_EMBED_TIMEOUT: 10s → 60s` (absorb tail latency on large batches, even on GPU)
- `MEMINI_RERANK_TIMEOUT: 8s → 30s`

## Validation

- [x] `flate test ks/hr --path ./kubernetes/apps/ai` → `ai/llmkube`, `ai/memini` pass (other blocks are cross-namespace deps, unrelated)
- [x] `flate diff ks/hr` against `origin/main` → exactly the planned changes
- [x] Rendered manifests verified: `runtimeClassName: nvidia`, `resources.gpu: 1`, `hardware.gpu` all present
- [x] Digest `ae35c11fb24b9478053a7ba6ab71d80a9937f3b5c7f6003ef12fe4b937b151f5` still resolvable on `ghcr.io/ggml-org/llama.cpp`

## Risks / rollback

| Risk | Mitigation |
|---|---|
| GPU removed for an unrecorded reason (OOM, driver crash) | nvidia-device-plugin has 5d3h uptime, no crash logs; `nvidia.com/gpu` allocatable=4 on k8s-3 |
| Image digest GC'd | Verified HTTP 200 on registry HEAD |
| `layers: 99` OOMs | 0.6B Q8_0 ≈ 600 MB VRAM, trivial vs modern GPU |

Rollback: revert this commit to return to the CPU configuration (slow but functional).

## Post-merge verification checklist

- [ ] `kubectl get pods -n ai -l app.kubernetes.io/name=qwen3-embedding-0.6b -o wide` → scheduled on `k8s-3`
- [ ] `kubectl describe node k8s-3 | grep -A5 "Allocated resources"` → `nvidia.com/gpu: 2` (1 embed + 1 rerank)
- [ ] `kubectl exec -n ai memini-main-0 -- time wget …/v1/embeddings` with a 400-token payload → <1s
- [ ] `kubectl logs -n ai memini-main-0 --tail=50 | grep "embed backfill"` → `pending=N` decreasing
- [ ] No more `cancel task` storms in `kubectl logs deploy/qwen3-embedding-0.6b -n ai`