### PR TITLE
fix(ai): revert qwen3-reranker to CPU (GTX 1050 Ti VRAM OOM)

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
@@ -8,13 +8,6 @@ spec:
   format: gguf
   quantization: Q8_0
   source: https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/main/qwen3-reranker-0.6b-q8_0.gguf
-  hardware:
-    accelerator: cuda
-    gpu:
-      count: 1
-      enabled: true
-      layers: 99
-      vendor: nvidia
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -24,8 +17,7 @@ metadata:
 spec:
   modelRef: qwen3-reranker-0.6b
   runtime: llamacpp
-  image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:ae35c11fb24b9478053a7ba6ab71d80a9937f3b5c7f6003ef12fe4b937b151f5
-  runtimeClassName: nvidia
+  image: ghcr.io/ggml-org/llama.cpp:server
   replicas: 1
   nodeSelector:
     kubernetes.io/hostname: k8s-3
@@ -39,16 +31,14 @@ spec:
   batchSize: 4096
   uBatchSize: 4096
   resources:
-    gpu: 1
     cpu: 100m
-    memory: 1Gi
+    memory: 2Gi
   extraArgs:
     - --rerank
     - --pooling
     - rank
     - --cache-ram
-    - "0"
-    - --no-mmap
+    - "512"
     - --alias
     - qwen3-reranker-0.6b
     - --metrics


### PR DESCRIPTION
## Summary

Hotfix to PR #3532. The reranker has been in `CrashLoopBackOff` since #3532 merged because the two qwen3 services cannot share the same physical GPU.

## Root cause

`k8s-3` actually has **1 physical GPU** (GTX 1050 Ti, 4 GB VRAM), but the `nvidia-device-plugin` is configured with time-slicing `replicas: 4` (`kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml:33`), so it advertises `nvidia.com/gpu: 4` to the scheduler. **Time-slicing provides no memory isolation** — all 4 slices map to the same physical device and compete for the same VRAM.

Sequence:
1. Embedder pod starts first, loads model + KV cache → **3562 MiB / 4096 MiB used** (confirmed via `nvidia-smi`)
2. Reranker pod (different slice, same physical GPU) attempts `cudaMalloc(604 MiB)` on the same device → only 456 MiB free → **OOM**

```
E ggml_backend_cuda_buffer_type_alloc_buffer: allocating 603.87 MiB
  on device 0: cudaMalloc failed: out of memory
E alloc_tensor_range: failed to allocate CUDA0 buffer of size 633207296
E llama_model_load: error loading model: unable to allocate CUDA0 buffer
```

This constraint wasn't visible until deploy — the device-plugin reports `nvidia.com/gpu: 4` in node capacity.

## Fix

Revert **only the reranker** to its pre-`5f748441e` CPU configuration. The embedder stays on GPU (it's the hot path — every memory write + the 1304-vectorless backfill).

| Field | Before (broken GPU) | After (CPU) |
|---|---|---|
| `Model.spec.hardware` | `cuda / gpu{count:1, layers:99}` | removed |
| `image` | `…:server-cuda@sha256:ae35c11f…` | `ghcr.io/ggml-org/llama.cpp:server` |
| `runtimeClassName` | `nvidia` | removed |
| `resources` | `{gpu:1, cpu:100m, memory:1Gi}` | `{cpu:100m, memory:2Gi}` |
| `extraArgs` | `--cache-ram 0 --no-mmap` | `--cache-ram 512` |

### Unchanged (intentional)

- `nodeSelector: kubernetes.io/hostname: k8s-3` — reranker stays pinned to k8s-3 even on CPU
- `tolerations` for `workload=ai:NoSchedule` — tolerates the node's taint
- `qwen3-embedding-0.6b.yaml` — stays on GPU (only one fits, and it's the bottleneck)
- `memini/app/helmrelease.yaml` — `MEMINI_RERANK_MAX_CONCURRENCY: 1` and `MEMINI_RERANK_TIMEOUT: 30s` from #3532 stay: they're even more useful on CPU

### Why the reranker tolerates CPU

- Called once per recall (vs embedder on every write + backfill)
- Reranks short top-K passages (~50-200 tokens) → ~1-4s at 50 tok/s on CPU
- Latency comfortably within `MEMINI_RERANK_TIMEOUT: 30s`

## Validation

- [x] `flate test ks/hr --path ./kubernetes/apps/ai` → all relevant resources pass
- [x] `flate diff ks` vs `origin/main` → only the planned revert on the reranker; embedder + memini untouched

## Post-merge verification

- [ ] `kubectl get pods -n ai -l app.kubernetes.io/name=qwen3-reranker-0.6b` → `1/1 Running`
- [ ] `kubectl describe node k8s-3 | grep -A3 "nvidia.com/gpu"` → `1` allocated (only the embedder)
- [ ] `kubectl logs -n ai deploy/qwen3-reranker-0.6b --tail=20` → `listening on http://[::]:8080`, no OOM
- [ ] `kubectl exec -n ai memini-main-0 -- wget …/v1/rerank` → response < 5s
- [ ] memini health: reranker no longer `rerank: request: … no such host` / OOM

## Follow-up (out of scope)

The `nvidia-device-plugin` time-slicing config (`replicas: 4`) without memory isolation is a latent footgun — any two VRAM-hungry workloads will collide the same way. Worth a separate issue to revisit: either `replicas: 1` (exclusive) or switch to MPS (the `nvidia-device-plugin-mps-control-daemon` DaemonSet is already deployed but has 0 ready pods).