### PR TITLE
feat(kube-system): switch GPU sharing from time-slicing to MPS

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -26,9 +26,8 @@ spec:
           flags:
             migStrategy: none
           sharing:
-            timeSlicing:
+            mps:
               renameByDefault: false
-              failRequestsGreaterThanOne: false
               resources:
                 - name: nvidia.com/gpu
                   replicas: 4


### PR DESCRIPTION
## Summary

Replace the `nvidia-device-plugin` time-slicing strategy with **MPS** (Multi-Process Service) so that the GTX 1050 Ti on `k8s-3` can serve multiple GPU workloads without the VRAM contention that has been blocking the memini reranker.

## Background

The current config:

```yaml
sharing:
  timeSlicing:
    renameByDefault: false
    failRequestsGreaterThanOne: false
    resources:
      - name: nvidia.com/gpu
        replicas: 4
```

…advertises `nvidia.com/gpu: 4` from a single physical GPU but provides **no memory isolation**. Each pod's container sees the entire VRAM pool and competes for it. This is the root cause of the reranker OOM in #3532:

```
E ggml_backend_cuda_buffer_type_alloc_buffer: allocating 603.87 MiB on device 0:
  cudaMalloc failed: out of memory
```

(embedder had already taken 3562/4096 MiB; reranker's 604 MiB allocation failed on the same physical device accessed via a different slice.)

## Change

```diff
   sharing:
-    timeSlicing:
+    mps:
       renameByDefault: false
-      failRequestsGreaterThanOne: false
       resources:
         - name: nvidia.com/gpu
           replicas: 4
```

MPS deploys a single daemon (`nvidia-cuda-mps-control`) that arbitrates GPU access between clients. Pods go through the MPS server instead of acquiring the device directly, eliminating context-switch overhead and giving both workloads a unified view of the GPU.

## What was already in place

The chart already deploys `nvidia-device-plugin-mps-control-daemon` as a DaemonSet, but it has been sitting at **0 ready pods** since deploy (7d) because it nodeSelectors on `nvidia.com/mps.capable=true` — a label the plugin only applies when MPS is configured. This PR flips the switch.

## Hardware compatibility

| Check | Value | OK? |
|---|---|---|
| GPU | NVIDIA GeForce GTX 1050 Ti | Pascal |
| Compute capability | **6.1** | ✅ MPS needs CC 3.5+ (Kepler+) |
| Driver | 580.167.08 | ✅ |
| Node label `nvidia.com/mps.capable` | (currently empty) | Will be set by the plugin post-deploy |

## What MPS does and doesn't do

| | Effect |
|---|---|
| ✅ Concurrent kernel execution | Two pods run truly in parallel instead of time-slicing |
| ✅ Lower context-switch overhead | Better latency for interleaved workloads |
| ✅ Unified VRAM view | Both pods see the device via a single MPS server |
| ❌ Hard memory isolation | The 4 GB ceiling is still shared — if both pods together request > 4 GB, OOM still occurs |

This PR alone **does not** fix the reranker OOM: the embedder (3.5 GB) + reranker (0.6 GB) total would still exceed 4 GB if both load fully into VRAM. The follow-up PR will restore the reranker on GPU with **partial offload** (`hardware.gpu.layers ~20`) to keep the combined footprint under the ceiling.

## Validation

- [x] `flate test hr --path ./kubernetes/apps/kube-system` → `nvidia-device-plugin` passes
- [x] `flate diff hr` vs `origin/main` → only the configmap `default` key changes (`timeSlicing` → `mps`, drop `failRequestsGreaterThanOne`)

## Post-merge verification

- [ ] `kubectl get pods -n kube-system -l app.kubernetes.io/name=nvidia-device-plugin-mps-control-daemon` → 1/1 Running on k8s-3
- [ ] `kubectl get node k8s-3 --show-labels | grep mps.capable` → `nvidia.com/mps.capable=true`
- [ ] `kubectl get node k8s-3 -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'` → still `4`
- [ ] `kubectl exec -n kube-system ds/nvidia-device-plugin-mps-control-daemon -- nvidia-smi` → MPS mode active (`Compute Mode = Exclusive Process` per client)
- [ ] **Embedder still works** (regression check): `kubectl exec -n ai memini-main-0 -- wget -qO- http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080/health` → `{"status":"ok"}`

## Risk and rollback

Risk: cluster-wide GPU plugin change. If MPS fails to initialize, all GPU workloads (currently just `qwen3-embedding-0.6b`) could be affected.

Rollback: revert this commit. The chart's `upgrade.cleanupOnFail: true` + `remediation.retries: 3` will also auto-revert on a failed helm upgrade.

## Follow-up (separate PR)

Once MPS is verified active and the embedder still works, restore GPU on `qwen3-reranker-0.6b` with `hardware.gpu.layers: 20` (partial offload) so both pods fit under the 4 GB ceiling. This is intentionally split to bisect risk: MPS-only first, reranker-GPU second.