### PR TITLE
fix(ai): compress qwen3 VRAM footprint, restore reranker on GPU

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -34,10 +34,10 @@ spec:
       operator: Equal
       value: ai
       effect: NoSchedule
-  contextSize: 4096
+  contextSize: 2048
   parallelSlots: 1
-  batchSize: 4096
-  uBatchSize: 4096
+  batchSize: 1024
+  uBatchSize: 1024
   resources:
     gpu: 1
     cpu: 100m

--- a/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
@@ -8,6 +8,13 @@ spec:
   format: gguf
   quantization: Q8_0
   source: https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/main/qwen3-reranker-0.6b-q8_0.gguf
+  hardware:
+    accelerator: cuda
+    gpu:
+      count: 1
+      enabled: true
+      layers: 99
+      vendor: nvidia
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -17,7 +24,8 @@ metadata:
 spec:
   modelRef: qwen3-reranker-0.6b
   runtime: llamacpp
-  image: ghcr.io/ggml-org/llama.cpp:server
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:ae35c11fb24b9478053a7ba6ab71d80a9937f3b5c7f6003ef12fe4b937b151f5
+  runtimeClassName: nvidia
   replicas: 1
   nodeSelector:
     kubernetes.io/hostname: k8s-3
@@ -26,19 +34,21 @@ spec:
       operator: Equal
       value: ai
       effect: NoSchedule
-  contextSize: 4096
+  contextSize: 2048
   parallelSlots: 1
-  batchSize: 4096
-  uBatchSize: 4096
+  batchSize: 1024
+  uBatchSize: 1024
   resources:
+    gpu: 1
     cpu: 100m
-    memory: 2Gi
+    memory: 1Gi
   extraArgs:
     - --rerank
     - --pooling
     - rank
     - --cache-ram
-    - "512"
+    - "0"
+    - --no-mmap
     - --alias
     - qwen3-reranker-0.6b
     - --metrics


### PR DESCRIPTION
## Summary

Follow-up to #3537 (MPS). Now that MPS is active, both qwen3 services can share the GTX 1050 Ti concurrently — but only if their combined VRAM footprint fits in 4 GB. This PR compresses both services' VRAM usage and restores the reranker on GPU.

## Background

After #3537 enabled MPS, `nvidia-smi` showed the embedder alone consuming **3562 MiB / 4096 MiB** at `layers=99 / contextSize=4096 / batchSize=4096`. The reranker's 604 MiB model load was OOM'ing (the original failure mode of #3532).

For a 0.6B embedding model, the dominant VRAM consumer is **batch activation memory** (batchSize=4096 = large intermediate buffers), not the model itself (~600 MiB) or the KV cache (~117 MiB at ctx=4096).

## Change

Compress both services' VRAM footprint symmetrically:

| Param | Before | After | Effect |
|---|---|---|---|
| `contextSize` | 4096 | **2048** | KV cache halved (~58 MiB freed per pod) |
| `batchSize` | 4096 | **1024** | Activation memory quartered (**dominant lever**) |
| `uBatchSize` | 4096 | **1024** | Micro-batch matches |

### Embedder (`qwen3-embedding-0.6b`)

Just the three compression params. Stays on GPU (`layers=99`).

**Estimated VRAM**: ~600 MiB model + ~60 MiB KV + ~700 MiB activations + ~150 MiB CUDA ctx ≈ **1.5 GiB** (vs 3.5 GiB before)

### Reranker (`qwen3-reranker-0.6b`)

Full GPU restore (revert of #3534) + same compression:

- `hardware` block: `cuda / gpu{count:1, layers:99}`
- `image: …server-cuda@sha256:ae35c11f…` (digest verified on GHCR)
- `runtimeClassName: nvidia`
- `resources.gpu: 1`, memory 2Gi → 1Gi
- `--cache-ram 0 --no-mmap` (fully VRAM-resident)
- Same ctx/batch compression as embedder

**Estimated VRAM**: ~1 GiB.

### Combined footprint

~2.5 GiB / 4 GiB → **~1.5 GiB headroom** with both fully in VRAM.

## Why compression is safe

- The backfill of 1304 vectorless memories is already drained (embedder on GPU since #3532)
- For typical memini embedding workloads (1 query + N short documents), `batchSize=1024` is far above what's actually sent — `MEMINI_RERANK_MAX_BATCH_CHARS: 6000` ≈ 1500 tokens per batch
- `contextSize=2048` is still 4× larger than any single memory content
- memini `MEMINI_RERANK_TIMEOUT: 30s` (set in #3532) gives ample budget on GPU

## What stays unchanged

- `memini/app/helmrelease.yaml` — `MEMINI_*_MAX_CONCURRENCY: 1`, `MEMINI_RECALL_EMBED_TIMEOUT: 60s`, `MEMINI_RERANK_TIMEOUT: 30s` from #3532 stay as-is
- `nodeSelector: kubernetes.io/hostname: k8s-3` + tolerations (both services)

## Validation

- [x] `flate test ks/hr --path ./kubernetes/apps/ai` → all relevant resources pass
- [x] `flate diff ks` vs `origin/main` → only the planned changes on both files

## Post-merge verification

- [ ] `kubectl get pods -n ai -l app.kubernetes.io/name=qwen3-reranker-0.6b` → `1/1 Running` on k8s-3
- [ ] `kubectl exec -n kube-system ds/nvidia-device-plugin -- nvidia-smi --query-gpu=memory.used,memory.free --format=csv` → ~2.5 GiB used, ~1.5 GiB free
- [ ] `kubectl exec -n kube-system ds/nvidia-device-plugin -- nvidia-smi --query-compute-apps=pid,used_memory --format=csv` → **two** processes (embedder + reranker)
- [ ] `kubectl exec -n ai memini-main-0 -- time wget …/v1/rerank` → <1s (vs 30s timeout on CPU)
- [ ] Recall via `POST /v1/search` no longer logs `WARN recall: rerank failed, using composite order`

## Operational caveat

The `nvidia.com/mps.capable=true` node label was applied manually on `k8s-3` to unblock the MPS daemon after #3537. **If `k8s-3` is rebuilt from Talos machine config, the label must be reapplied** (`kubectl label node k8s-3 nvidia.com/mps.capable=true`) — otherwise the `nvidia-device-plugin-mps-control-daemon` DaemonSet goes back to 0 ready pods and the device-plugin refuses to advertise the GPU. Worth tracking in a separate follow-up (NodeLabel via Talos machine config, or a startup Job).