### PR TITLE
revert(kube-system): switch GPU sharing back to time-slicing (MPS inc…

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -26,8 +26,9 @@ spec:
           flags:
             migStrategy: none
           sharing:
-            mps:
+            timeSlicing:
               renameByDefault: false
+              failRequestsGreaterThanOne: false
               resources:
                 - name: nvidia.com/gpu
                   replicas: 4


### PR DESCRIPTION
…ompatible with GeForce)

Reverts #3537. NVIDIA MPS server fails to start on the GTX 1050 Ti with 'server exited with status 1' in /mps/nvidia.com/gpu/log/control.log and an empty server.log — the documented signature for an unsupported GPU SKU.

MPS is gated to NVIDIA Tesla/Quadro/Data Center GPUs. GeForce consumer cards (despite meeting the compute-capability 3.5+ requirement) cannot run the MPS server. The control daemon accepts client connections but every per-user server process exits immediately, so both qwen3 pods fall through to silent CPU fallback with 'MPS client failed to connect to the MPS control daemon or the MPS server'.

PR #3539 (compress qwen3 VRAM + restore reranker on GPU) is unaffected and remains the right direction: the embedder (~1.5 GiB) and reranker (~1 GiB) fit comfortably in 4 GiB even without memory isolation, so plain timeSlicing.replicas=4 is sufficient.