### PR TITLE
feat(ai): migrate lightrag embeddings from TEI bge-m3 to qwen3-0.6b

### DIFF
--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -38,15 +38,22 @@ spec:
               MAX_ASYNC_LLM: "2"
               LLM_TIMEOUT: "480"
               CHUNK_SIZE: "800"
-              # Embeddings via local TEI (OpenAI-compatible)
+              # Embeddings via llmkube qwen3-embedding-0.6b (OpenAI-compatible, GPU shared with memini)
               EMBEDDING_BINDING: openai
-              EMBEDDING_BINDING_HOST: http://embeddings.ai.svc.cluster.local:80
-              EMBEDDING_MODEL: BAAI/bge-m3
+              EMBEDDING_BINDING_HOST: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080
+              EMBEDDING_MODEL: qwen3-embedding-0.6b
               EMBEDDING_DIM: "1024"
-              EMBEDDING_TOKEN_LIMIT: "8192"
+              # qwen3 expects asymmetric prefixes (instruct on query, none on doc);
+              # EMBEDDING_DOCUMENT_PREFIX=NO_PREFIX is LightRag's sentinel for "no doc prefix".
+              EMBEDDING_ASYMMETRIC: "true"
+              EMBEDDING_QUERY_PREFIX: "Instruct: Given a user message, retrieve relevant past memories\nQuery: "
+              EMBEDDING_DOCUMENT_PREFIX: "NO_PREFIX"
+              # qwen3 ctx=2048; keep headroom for prefix + special tokens
+              EMBEDDING_TOKEN_LIMIT: "1800"
               EMBEDDING_BINDING_API_KEY: not-required
-              EMBEDDING_BATCH_NUM: "16"
-              EMBEDDING_FUNC_MAX_ASYNC: "2"
+              # Shared GTX 1050 Ti (time-slicing, parallelSlots=1): keep batches small
+              EMBEDDING_BATCH_NUM: "4"
+              EMBEDDING_FUNC_MAX_ASYNC: "1"
               EMBEDDING_TIMEOUT: "120"
 
             envFrom:


### PR DESCRIPTION
Switch lightrag's embedding backend from the dedicated TEI bge-m3 CPU deployment to the shared llmkube qwen3-embedding-0.6b GPU service, mutualizing resources with memini on the GTX 1050 Ti (time-slicing).

Key changes:
- EMBEDDING_BINDING_HOST -> qwen3-embedding-0-6b.ai:8080
- EMBEDDING_MODEL -> qwen3-embedding-0.6b (dim 1024 unchanged)
- Enable asymmetric prefix support (EMBEDDING_ASYMMETRIC=true) since qwen3 expects an instruct prefix on queries and none on documents; EMBEDDING_QUERY_PREFIX mirrors the memini/canonical qwen3 prefix, EMBEDDING_DOCUMENT_PREFIX=NO_PREFIX is LightRag's no-op sentinel.
- EMBEDDING_TOKEN_LIMIT 8192 -> 1800 to fit qwen3's 2048 context window with headroom for the prefix and special tokens.
- EMBEDDING_BATCH_NUM 16 -> 4 and EMBEDDING_FUNC_MAX_ASYNC 2 -> 1 to play nice with the shared GPU (parallelSlots=1).

Post-merge operational step (manual): wipe /app/data/rag_storage/* in the lightrag pod and restart to trigger a full re-ingest of the 4 PDFs in INPUT_DIR via the new embedding model. A backup of the current rag_storage has been snapshot locally before rollout.