### PR TITLE
feat(kopiur): enable native kopia web-UI server

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
     features:
       credentialProjection:
         enabled: true
-      kopiaUI:
+      kopiaUi:
         enabled: true
     monitoring:
       dashboards:

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 metadata:
   name: kopiur
 spec:
+  dependsOn:
+    - name: snapshot-controller
+      namespace: kube-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -25,6 +25,20 @@ spec:
     refreshInterval: 1h
   create:
     enabled: false # adopt the existing volsync kopia repository, never re-initialize
+  server:
+    namespace: kopiur-system
+    auth:
+      generate:
+        username: admin
+    readOnly: true
+    service:
+      type: ClusterIP
+      port: 51515
+    podSecurityContext:
+      runAsUser: 1024
+      runAsGroup: 100
+      fsGroup: 100
+      fsGroupChangePolicy: OnRootMismatch
   credentialProjection:
     allowed: true
   identityDefaults:

--- a/kubernetes/apps/kopiur-system/kopiur/repository/httproute.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/httproute.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nas-kopia-ui
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - kopia-ui.oxygn.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: nas-kopia-ui
+          namespace: kopiur-system
+          port: 51515

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./clusterrepository.yaml
+  - ./httproute.yaml


### PR DESCRIPTION
Activates the operator-managed kopia web-UI on ClusterRepository/nas via spec.server, replacing the standalone kopia pod (decommissioned in a follow-up). This is the first half of the volsync decommission.

- fix(app): correct chart value casing kopiaUI -> kopiaUi (the typo silently left kopiaUi.enabled at its false default)
- feat(repository): add spec.server (auth.generate, readOnly, port 51515, podSecurityContext matching the NFS repo owner 1024:100) so the operator deploys a Deployment+Service+auth Secret
- feat(repository): add HTTPRoute kopia-ui.oxygn.dev (temporary hostname; renamed to kopia.oxygn.dev once the standalone is removed)
- fix(ks): add dependsOn snapshot-controller/kube-system to close the latent bootstrap-ordering gap (kopiur creates VolumeSnapshot CRs)