### PR TITLE
fix(ai): pin mcp<2 for lightrag-mcp to fix CrashLoopBackOff

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/lightrag-mcp/mcpserver.yaml
@@ -32,6 +32,10 @@ spec:
           command:
             - uvx
           args:
+            # mcp 2.0 (2026-07-28) removed mcp.server.fastmcp; mcp-lightrag 0.2.2
+            # declares mcp>=1.2.0 with no upper bound, so constrain to latest 1.x.
+            - --with
+            - mcp<2
             # renovate: datasource=pypi depName=mcp-lightrag
             - mcp-lightrag==0.2.2
           env:


### PR DESCRIPTION
mcp-lightrag 0.2.2 declares mcp>=1.2.0 with no upper bound. mcp 2.0.0 (2026-07-28) removed mcp.server.fastmcp, so uvx now resolves 2.x and the container crashes on import with ModuleNotFoundError: No module named 'mcp.server.fastmcp' (267 restarts, MCPServer phase=Failed).

Add 'uvx --with mcp<2' to constrain resolution to latest 1.x (1.9.4), which still ships mcp.server.fastmcp.