### PR TITLE
fix(self-hosted): opt-in to kopiur privileged movers

### DIFF
--- a/kubernetes/apps/self-hosted/namespace.yaml
+++ b/kubernetes/apps/self-hosted/namespace.yaml
@@ -5,5 +5,6 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    kopiur.home-operations.com/privileged-movers: "true"
   labels:
     resource.kubernetes.io/admin-access: "true"


### PR DESCRIPTION
After the volsync -> kopiur/miroir migration, the self-hosted namespace still carried the dead volsync.backube/privileged-movers annotation and was missing the kopiur.home-operations.com/privileged-movers opt-in.

kopiur's PrivilegedMoverNotPermitted gate therefore blocked the nextcloud Restore (which requests runAsUser: 0 via KOPIUR_PUID "0"), leaving the PVC unpopulated, the app pod Pending, and the nextcloud HelmRelease stuck in a rollback loop.