### PR TITLE
feat(toolhive): expose grafana-mcp to mcp-tools group

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./mcpserverentry.yaml
+  - ./mcpserverentry-internal.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp/mcpserverentry-internal.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana-mcp/mcpserverentry-internal.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserverentry_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServerEntry
+metadata:
+  name: grafana-internal
+spec:
+  remoteUrl: http://grafana-mcp.observability:8000/sse
+  transport: sse
+  groupRef:
+    name: mcp-tools


### PR DESCRIPTION
## What

Adds a second `MCPServerEntry` (`grafana-internal`) that points to the same `grafana-mcp.observability:8000/sse` service but registers it in the `mcp-tools` group instead of `mcp-devops`.

## Why

Currently grafana-mcp is only in the `mcp-devops` group → only devclaw (`mcp-gateway-devops`) has access. mainclaw connects to `mcp-gateway-internal` (group `mcp-tools`) and can't see grafana tools.

Since `MCPServerEntry.groupRef` is a single value, the cleanest approach is a second entry with the same `remoteUrl` but different group.

## Changes

| File | Change |
|---|---|
| `mcpserverentry-internal.yaml` | **New** — MCPServerEntry `grafana-internal` with `groupRef: mcp-tools` |
| `kustomization.yaml` | Add `mcpserverentry-internal.yaml` to resources |

## Validation

- `flate test ks` ✅ (8 passed, 5 blocked by cross-namespace deps — normal)