### PR TITLE
feat(toolhive): add teslamate-mcp server to mcp-tools group

### DIFF
--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -149,6 +149,32 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: &name teslamate-mcp-entry
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  dependsOn:
+    - name: toolhive
+    - name: teslamate-mcp
+      namespace: automation
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/mcp-servers/teslamate-mcp
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: &name radar-mcp-entry
 spec:
   commonMetadata:

--- a/kubernetes/apps/ai/toolhive/mcp-servers/teslamate-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/teslamate-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverentry.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/teslamate-mcp/mcpserverentry.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/teslamate-mcp/mcpserverentry.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserverentry_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServerEntry
+metadata:
+  name: teslamate
+spec:
+  remoteUrl: http://teslamate-mcp.automation:8888/mcp
+  transport: streamable-http
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/automation/teslamate/ks.yaml
+++ b/kubernetes/apps/automation/teslamate/ks.yaml
@@ -32,3 +32,27 @@ spec:
     namespace: flux-system
   targetNamespace: automation
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &name teslamate-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *name
+  dependsOn:
+    - name: teslamate
+  interval: 1h
+  path: ./kubernetes/apps/automation/teslamate/mcp
+  postBuild:
+    substitute:
+      APP: *name
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: automation
+  wait: false

--- a/kubernetes/apps/automation/teslamate/mcp/helmrelease.yaml
+++ b/kubernetes/apps/automation/teslamate/mcp/helmrelease.yaml
@@ -1,0 +1,95 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: teslamate-mcp
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: teslamate-mcp
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      teslamate-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/cobanov/teslamate-mcp
+              tag: 0.3.1@sha256:8a13073e8c9729c93f23c9718e89452162b553dd3374b72fd187625f61d54e4d
+            # DATABASE_URL is composed at startup from the CloudNativePG
+            # teslamate-app secret and pointed at the read-only replicas
+            # service (teslamate-ro) for engine-level read-only access.
+            command: ["/bin/sh", "-c"]
+            args:
+              - >-
+                export DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@teslamate-ro.automation.svc.cluster.local:5432/${DB_NAME}"
+                && exec teslamate-mcp http --host 0.0.0.0 --port 8888 --json-response
+            env:
+              DB_USER:
+                secretKeyRef:
+                  name: teslamate-app
+                  key: username
+              DB_PASS:
+                secretKeyRef:
+                  name: teslamate-app
+                  key: password
+              DB_NAME:
+                secretKeyRef:
+                  name: teslamate-app
+                  key: dbname
+              HOME: /tmp
+            probes:
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8888
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+              liveness:
+                enabled: false
+              startup:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: teslamate-mcp
+        type: ClusterIP
+        ports:
+          http:
+            port: 8888
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/automation/teslamate/mcp/kustomization.yaml
+++ b/kubernetes/apps/automation/teslamate/mcp/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/automation/teslamate/mcp/ocirepository.yaml
+++ b/kubernetes/apps/automation/teslamate/mcp/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: teslamate-mcp
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
Deploy the cobanov/teslamate-mcp server (v0.3.1) to expose TeslaMate analytics to AI assistants via the mcp-tools group, following the established MCPServerEntry pattern (workload + reference):

- automation/teslamate/mcp: workload running next to the TeslaMate DB, composing DATABASE_URL from the CloudNativePG teslamate-app secret and pointing at teslamate-ro for engine-level read-only access.
- ai/toolhive/mcp-servers/teslamate-mcp: MCPServerEntry registering the remote workload into the mcp-tools group (streamable-http).