### PR TITLE
fix(teslamate): increase CNP memory limit to 1Gi

### DIFF
--- a/kubernetes/apps/automation/teslamate/app/kustomization.yaml
+++ b/kubernetes/apps/automation/teslamate/app/kustomization.yaml
@@ -8,3 +8,18 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadatasource.yaml
   - ./grafanadashboard.yaml
+patches:
+  - target:
+      kind: Cluster
+      name: ${APP}
+    patch: |
+      apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      metadata:
+        name: ${APP}
+      spec:
+        resources:
+          requests:
+            memory: 768Mi
+          limits:
+            memory: 1Gi


### PR DESCRIPTION
## What

Patches the CloudNativePG `Cluster` for TeslaMate to raise the memory limit from **850Mi → 1Gi** (requests 512Mi → 768Mi).

## Why

`teslamate-1` and `teslamate-3` repeatedly OOMKilled (exit 137, 2 restarts each). The default 850Mi limit comes from the shared `postgres` component — TeslaMate needs more headroom.

Last OOM: today 07:10 (after ~14h of run). Current usage ranges 94–218Mi but climbs progressively.

## Changes

| File | Change |
|---|---|
| `teslamate/app/kustomization.yaml` | Add strategic merge patch on CNP `Cluster` → limits 1Gi, requests 768Mi |

Only affects TeslaMate — other CNP clusters using the `postgres` component are untouched.